### PR TITLE
Select Market Sector Fix

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,7 +2,14 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/Slick2D"/>
+	<classpathentry kind="lib" path="jar/jacocoagent.jar"/>
+	<classpathentry kind="lib" path="jar/jacocoant.jar"/>
+	<classpathentry kind="lib" path="jar/junit.jar"/>
+	<classpathentry kind="lib" path="jar/org.jacoco.agent-0.7.4.201502262128.jar"/>
+	<classpathentry kind="lib" path="jar/org.jacoco.ant-0.7.4.201502262128.jar"/>
+	<classpathentry kind="lib" path="jar/org.jacoco.core-0.7.4.201502262128.jar"/>
+	<classpathentry kind="lib" path="jar/org.jacoco.report-0.7.4.201502262128.jar"/>
+	<classpathentry kind="lib" path="slick/lib/commons-math3-3.3.jar"/>
 	<classpathentry kind="lib" path="slick/lib/ibxm.jar"/>
 	<classpathentry kind="lib" path="slick/lib/jinput.jar"/>
 	<classpathentry kind="lib" path="slick/lib/jnlp.jar"/>
@@ -18,18 +25,9 @@
 	<classpathentry kind="lib" path="slick/lib/slick-examples.jar"/>
 	<classpathentry kind="lib" path="slick/lib/slick.jar">
 		<attributes>
-			<attribute name="org.eclipse.jdt.launching.CLASSPATH_ATTR_LIBRARY_PATH_ENTRY" value="C:/Users/Owner/Desktop/cst316/project/316Life/life/slick"/>
+			<attribute name="org.eclipse.jdt.launching.CLASSPATH_ATTR_LIBRARY_PATH_ENTRY" value="gameoflife/slick"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="lib" path="slick/lib/tinylinepp.jar"/>
-
-	<classpathentry kind="lib" path="jar/jacocoagent.jar"/>
-	<classpathentry kind="lib" path="jar/jacocoant.jar"/>
-	<classpathentry kind="lib" path="jar/junit.jar"/>
-	<classpathentry kind="lib" path="jar/org.jacoco.agent-0.7.4.201502262128.jar"/>
-	<classpathentry kind="lib" path="jar/org.jacoco.ant-0.7.4.201502262128.jar"/>
-	<classpathentry kind="lib" path="jar/org.jacoco.core-0.7.4.201502262128.jar"/>
-	<classpathentry kind="lib" path="jar/org.jacoco.report-0.7.4.201502262128.jar"/>
-
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/hs_err_pid8958.log
+++ b/hs_err_pid8958.log
@@ -1,0 +1,620 @@
+#
+# A fatal error has been detected by the Java Runtime Environment:
+#
+#  SIGSEGV (0xb) at pc=0x00007fff97b560dd, pid=8958, tid=1811
+#
+# JRE version: Java(TM) SE Runtime Environment (8.0_31-b13) (build 1.8.0_31-b13)
+# Java VM: Java HotSpot(TM) 64-Bit Server VM (25.31-b07 mixed mode bsd-amd64 compressed oops)
+# Problematic frame:
+# C  [libobjc.A.dylib+0x10dd]  objc_msgSend+0x1d
+#
+# Failed to write core dump. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
+#
+# If you would like to submit a bug report, please visit:
+#   http://bugreport.java.com/bugreport/crash.jsp
+# The crash happened outside the Java Virtual Machine in native code.
+# See problematic frame for where to report the bug.
+#
+
+---------------  T H R E A D  ---------------
+
+Current thread (0x00007fd2f3894000):  JavaThread "AppKit Thread" daemon [_thread_in_native, id=1811, stack(0x00007fff5a34d000,0x00007fff5ab4d000)]
+
+siginfo: si_signo: 11 (SIGSEGV), si_code: 1 (SEGV_MAPERR), si_addr: 0x000007fd2f1c7d80
+
+Registers:
+RAX=0x00007fd2f1c7f480, RBX=0x00007fff5ab48448, RCX=0x0000000000000000, RDX=0x00007fd2f437b0f0
+RSP=0x00007fff5ab48268, RBP=0x00007fff5ab48270, RSI=0x00007fff901e02b4, RDI=0x00007fd2f1c7f480
+R8 =0x00007fff5ab48250, R9 =0x0000000000000063, R10=0x00007fff901e02b4, R11=0x000007fd2f1c7d68
+R12=0x00007fd2f1d03130, R13=0x00000000000f43a4, R14=0x00007fd2f1c80f30, R15=0x00007fff5ab483a8
+RIP=0x00007fff97b560dd, EFLAGS=0x0000000000010202, ERR=0x0000000000000004
+  TRAPNO=0x000000000000000e
+
+Top of Stack: (sp=0x00007fff5ab48268)
+0x00007fff5ab48268:   00007fff90a8ecdc 00007fff5ab485d0
+0x00007fff5ab48278:   00007fff90980244 00007fff5ab482fc
+0x00007fff5ab48288:   00007fff5ab48300 00007fff5ab48304
+0x00007fff5ab48298:   00007fff7e5a1c88 ffffffffffffffff
+0x00007fff5ab482a8:   0000000000000948 00007fff7e5a1ca0
+0x00007fff5ab482b8:   00007fd2f1c80f30 0000000000000000
+0x00007fff5ab482c8:   00007fff5ab483a0 0000000000000000
+0x00007fff5ab482d8:   00007fd2f1e92c40 00007fff5ab48420
+0x00007fff5ab482e8:   0000000000000063 00000000000f43a6
+0x00007fff5ab482f8:   00007fd2f437b0f0 00007fd2f1e92670
+0x00007fff5ab48308:   00007fd2f1d03130 0000000000000001
+0x00007fff5ab48318:   00000000000f43a4 00007fd2f1d03120
+0x00007fff5ab48328:   00007fff946047ba 00000001f380b6a0
+0x00007fff5ab48338:   00007fff7f6e20d0 0000000042000000
+0x00007fff5ab48348:   00007fff9460ce13 00007fff7e56c1d0
+0x00007fff5ab48358:   00007fff5ab48428 0000000000000000
+0x00007fff5ab48368:   00007fff7eb4a8c8 0000000000000000
+0x00007fff5ab48378:   0000000000000014 001a730300000001
+0x00007fff5ab48388:   00007fd2f1d03154 0000000000000000
+0x00007fff5ab48398:   000000000054e301 00007fd2f1e92cc0
+0x00007fff5ab483a8:   00007fd2f1c80f30 0000000000000000
+0x00007fff5ab483b8:   00007fff9021834c 00007fff5ab48460
+0x00007fff5ab483c8:   00007fff9b943513 00007fff5ab48444
+0x00007fff5ab483d8:   000000000054e401 00000000ffffffff
+0x00007fff5ab483e8:   00007fff7eb4a8c8 000000000054e400
+0x00007fff5ab483f8:   00007fff00000000 00007fff5ab484f0
+0x00007fff5ab48408:   00007fff9ae8fedc 00007fff7eb4a8e8
+0x00007fff5ab48418:   00007fff9021834c 0000000000000052
+0x00007fff5ab48428:   0000000000000000 00000000000f42e3
+0x00007fff5ab48438:   0000000000000054 0000000000000000
+0x00007fff5ab48448:   00000000000f43a4 00007fff5ab484c4
+0x00007fff5ab48458:   000000000054eb01 00000000ffffffff 
+
+Instructions: (pc=0x00007fff97b560dd)
+0x00007fff97b560bd:   00 00 00 48 85 ff 2e 74 7a 40 f6 c7 01 2e 75 7e
+0x00007fff97b560cd:   49 bb f8 ff ff ff ff 7f 00 00 4c 23 1f 49 89 f2
+0x00007fff97b560dd:   45 23 53 18 49 c1 e2 04 4d 03 53 10 49 3b 32 75
+0x00007fff97b560ed:   04 41 ff 62 08 49 83 3a 00 74 6a 4d 3b 53 10 74 
+
+Register to memory mapping:
+
+RAX=0x00007fd2f1c7f480 is an unknown value
+RBX=0x00007fff5ab48448 is pointing into the stack for thread: 0x00007fd2f3894000
+RCX=0x0000000000000000 is an unknown value
+RDX=0x00007fd2f437b0f0 is an unknown value
+RSP=0x00007fff5ab48268 is pointing into the stack for thread: 0x00007fd2f3894000
+RBP=0x00007fff5ab48270 is pointing into the stack for thread: 0x00007fd2f3894000
+RSI=0x00007fff901e02b4: -[NSTitlebarContainerView shouldRoundCorners]+0x5ced6 in /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit at 0x00007fff8f80f000
+RDI=0x00007fd2f1c7f480 is an unknown value
+R8 =0x00007fff5ab48250 is pointing into the stack for thread: 0x00007fd2f3894000
+R9 =0x0000000000000063 is an unknown value
+R10=0x00007fff901e02b4: -[NSTitlebarContainerView shouldRoundCorners]+0x5ced6 in /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit at 0x00007fff8f80f000
+R11=0x000007fd2f1c7d68 is an unknown value
+R12=0x00007fd2f1d03130 is an unknown value
+R13=0x00000000000f43a4 is an unknown value
+R14=0x00007fd2f1c80f30 is an unknown value
+R15=0x00007fff5ab483a8 is pointing into the stack for thread: 0x00007fd2f3894000
+
+
+Stack: [0x00007fff5a34d000,0x00007fff5ab4d000],  sp=0x00007fff5ab48268,  free space=8172k
+Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
+C  [libobjc.A.dylib+0x10dd]  objc_msgSend+0x1d
+C  [CoreFoundation+0x10244]  _CFXNotificationPost+0xc44
+C  [Foundation+0x2c31]  -[NSNotificationCenter postNotificationName:object:userInfo:]+0x42
+C  [AppKit+0xdd776]  -[NSSurface _disposeSurface]+0x98
+C  [AppKit+0xdd1da]  -[NSSurface setWindow:]+0x42
+C  [AppKit+0x3b9ef]  -[NSView _setWindow:]+0xa22
+C  [AppKit+0x3cc22]  -[NSView removeFromSuperview]+0x1c5
+C  [AppKit+0x9140a]  -[NSView removeFromSuperviewWithoutNeedingDisplay]+0x26
+C  [liblwjgl.dylib+0xa205]  +[MacOSXKeyableWindow destroyWindow]+0xb5
+C  [Foundation+0x65cdc]  __NSThreadPerformPerform+0x125
+C  [CoreFoundation+0x80681]  __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__+0x11
+C  [CoreFoundation+0x7280d]  __CFRunLoopDoSources0+0x10d
+C  [CoreFoundation+0x71e3f]  __CFRunLoopRun+0x39f
+C  [CoreFoundation+0x71858]  CFRunLoopRunSpecific+0x128
+C  [HIToolbox+0x2eaef]  RunCurrentEventLoopInMode+0xeb
+C  [HIToolbox+0x2e76e]  ReceiveNextEventCommon+0xb3
+C  [HIToolbox+0x2e6ab]  _BlockUntilNextEventMatchingListInModeWithFilter+0x47
+C  [AppKit+0x23f81]  _DPSNextEvent+0x3c4
+C  [AppKit+0x23730]  -[NSApplication nextEventMatchingMask:untilDate:inMode:dequeue:]+0xc2
+C  [libosxapp.dylib+0x242a]  -[NSApplicationAWT nextEventMatchingMask:untilDate:inMode:dequeue:]+0x7c
+C  [AppKit+0x17593]  -[NSApplication run]+0x252
+C  [libosxapp.dylib+0x223e]  +[NSApplicationAWT runAWTLoopWithApp:]+0x9c
+C  [libawt_lwawt.dylib+0x4494f]  -[AWTStarter starter:]+0x389
+C  [Foundation+0x65cdc]  __NSThreadPerformPerform+0x125
+C  [CoreFoundation+0x80681]  __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__+0x11
+C  [CoreFoundation+0x7280d]  __CFRunLoopDoSources0+0x10d
+C  [CoreFoundation+0x71e3f]  __CFRunLoopRun+0x39f
+C  [CoreFoundation+0x71858]  CFRunLoopRunSpecific+0x128
+C  [java+0x56cc]  CreateExecutionEnvironment+0x367
+C  [java+0x165c]  JLI_Launch+0x7a0
+C  [java+0x768a]  main+0x65
+C  [java+0xeb4]  start+0x34
+C  0x0000000000000006
+
+
+---------------  P R O C E S S  ---------------
+
+Java Threads: ( => current thread )
+  0x00007fd2f389b000 JavaThread "AWT-Shutdown" [_thread_blocked, id=37227, stack(0x00000001599c9000,0x0000000159ac9000)]
+  0x00007fd2f39f5000 JavaThread "Java2D Disposer" daemon [_thread_blocked, id=59155, stack(0x00000001311c9000,0x00000001312c9000)]
+  0x00007fd2f3981800 JavaThread "Java2D Queue Flusher" daemon [_thread_blocked, id=59911, stack(0x000000013082d000,0x000000013092d000)]
+=>0x00007fd2f3894000 JavaThread "AppKit Thread" daemon [_thread_in_native, id=1811, stack(0x00007fff5a34d000,0x00007fff5ab4d000)]
+  0x00007fd2f383a000 JavaThread "Service Thread" daemon [_thread_blocked, id=17923, stack(0x000000011e682000,0x000000011e782000)]
+  0x00007fd2f3831000 JavaThread "C1 CompilerThread2" daemon [_thread_blocked, id=17411, stack(0x000000011e57f000,0x000000011e67f000)]
+  0x00007fd2f3830800 JavaThread "C2 CompilerThread1" daemon [_thread_blocked, id=16899, stack(0x000000011e47c000,0x000000011e57c000)]
+  0x00007fd2f380d800 JavaThread "C2 CompilerThread0" daemon [_thread_blocked, id=16387, stack(0x000000011e379000,0x000000011e479000)]
+  0x00007fd2f380a800 JavaThread "Signal Dispatcher" daemon [_thread_blocked, id=14095, stack(0x000000011e276000,0x000000011e376000)]
+  0x00007fd2f382d000 JavaThread "Finalizer" daemon [_thread_blocked, id=11523, stack(0x000000011c9b8000,0x000000011cab8000)]
+  0x00007fd2f382c800 JavaThread "Reference Handler" daemon [_thread_blocked, id=11011, stack(0x000000011c8b5000,0x000000011c9b5000)]
+  0x00007fd2f2800000 JavaThread "main" [_thread_in_native, id=4867, stack(0x00000001060e8000,0x00000001061e8000)]
+
+Other Threads:
+  0x00007fd2f382a000 VMThread [stack: 0x000000011c7b2000,0x000000011c8b2000] [id=10499]
+  0x00007fd2f301d000 WatcherThread [stack: 0x000000011e785000,0x000000011e885000] [id=18435]
+
+VM state:not at safepoint (normal execution)
+
+VM Mutex/Monitor currently owned by a thread: None
+
+Heap:
+ PSYoungGen      total 98304K, used 91403K [0x0000000795580000, 0x000000079c480000, 0x00000007c0000000)
+  eden space 93696K, 92% used [0x0000000795580000,0x000000079aa5aec8,0x000000079b100000)
+  from space 4608K, 97% used [0x000000079bb80000,0x000000079bfe8040,0x000000079c000000)
+  to   space 4608K, 0% used [0x000000079c000000,0x000000079c000000,0x000000079c480000)
+ ParOldGen       total 87552K, used 15826K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 18% used [0x0000000740000000,0x0000000740f74840,0x0000000745580000)
+ Metaspace       used 10522K, capacity 10657K, committed 10880K, reserved 1058816K
+  class space    used 1070K, capacity 1117K, committed 1152K, reserved 1048576K
+
+Card table byte_map: [0x0000000115e05000,0x0000000116206000] byte_map_base: 0x0000000112405000
+
+Marking Bits: (ParMarkBitMap*) 0x0000000105a4f410
+ Begin Bits: [0x00000001168bd000, 0x00000001188bd000)
+ End Bits:   [0x00000001188bd000, 0x000000011a8bd000)
+
+Polling page: 0x00000001061f8000
+
+CodeCache: size=245760Kb used=5422Kb max_used=5542Kb free=240337Kb
+ bounds [0x0000000106a45000, 0x0000000106fd5000, 0x0000000115a45000]
+ total_blobs=1948 nmethods=1419 adapters=443
+ compilation: enabled
+
+Compilation events (10 events):
+Event: 547.254 Thread 0x00007fd2f380d800 1654       4       sun.misc.URLClassPath::getResource (74 bytes)
+Event: 547.326 Thread 0x00007fd2f380d800 nmethod 1654 0x0000000106fcb110 code [0x0000000106fcb4a0, 0x0000000106fcd738]
+Event: 547.735 Thread 0x00007fd2f3830800 1655       4       org.newdawn.slick.Image::draw (236 bytes)
+Event: 547.758 Thread 0x00007fd2f3830800 nmethod 1655 0x0000000106d18890 code [0x0000000106d18d20, 0x0000000106d1a538]
+Event: 548.035 Thread 0x00007fd2f380d800 1656       4       java.lang.String::getBytes (27 bytes)
+Event: 548.036 Thread 0x00007fd2f380d800 nmethod 1656 0x0000000106d1f810 code [0x0000000106d1f960, 0x0000000106d1fa28]
+Event: 548.836 Thread 0x00007fd2f3830800 1657       4       java.nio.HeapByteBuffer::putInt (20 bytes)
+Event: 548.838 Thread 0x00007fd2f3830800 nmethod 1657 0x0000000106d89990 code [0x0000000106d89ae0, 0x0000000106d89c68]
+Event: 548.866 Thread 0x00007fd2f380d800 1658       4       java.lang.String::substring (56 bytes)
+Event: 548.870 Thread 0x00007fd2f380d800 nmethod 1658 0x0000000106d00a90 code [0x0000000106d00c00, 0x0000000106d00f78]
+
+GC Heap History (10 events):
+Event: 537.175 GC heap before
+{Heap before GC invocations=147 (full 0):
+ PSYoungGen      total 119296K, used 116096K [0x0000000795580000, 0x000000079d080000, 0x00000007c0000000)
+  eden space 112640K, 100% used [0x0000000795580000,0x000000079c380000,0x000000079c380000)
+  from space 6656K, 51% used [0x000000079ca00000,0x000000079cd60030,0x000000079d080000)
+  to   space 6656K, 0% used [0x000000079c380000,0x000000079c380000,0x000000079ca00000)
+ ParOldGen       total 87552K, used 15754K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 17% used [0x0000000740000000,0x0000000740f62840,0x0000000745580000)
+ Metaspace       used 10465K, capacity 10593K, committed 10880K, reserved 1058816K
+  class space    used 1069K, capacity 1117K, committed 1152K, reserved 1048576K
+Event: 537.179 GC heap after
+Heap after GC invocations=147 (full 0):
+ PSYoungGen      total 113152K, used 4512K [0x0000000795580000, 0x000000079cc80000, 0x00000007c0000000)
+  eden space 108544K, 0% used [0x0000000795580000,0x0000000795580000,0x000000079bf80000)
+  from space 4608K, 97% used [0x000000079c380000,0x000000079c7e8040,0x000000079c800000)
+  to   space 4608K, 0% used [0x000000079c800000,0x000000079c800000,0x000000079cc80000)
+ ParOldGen       total 87552K, used 15762K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 18% used [0x0000000740000000,0x0000000740f64840,0x0000000745580000)
+ Metaspace       used 10465K, capacity 10593K, committed 10880K, reserved 1058816K
+  class space    used 1069K, capacity 1117K, committed 1152K, reserved 1048576K
+}
+Event: 537.643 GC heap before
+{Heap before GC invocations=148 (full 0):
+ PSYoungGen      total 113152K, used 113056K [0x0000000795580000, 0x000000079cc80000, 0x00000007c0000000)
+  eden space 108544K, 100% used [0x0000000795580000,0x000000079bf80000,0x000000079bf80000)
+  from space 4608K, 97% used [0x000000079c380000,0x000000079c7e8040,0x000000079c800000)
+  to   space 4608K, 0% used [0x000000079c800000,0x000000079c800000,0x000000079cc80000)
+ ParOldGen       total 87552K, used 15762K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 18% used [0x0000000740000000,0x0000000740f64840,0x0000000745580000)
+ Metaspace       used 10465K, capacity 10593K, committed 10880K, reserved 1058816K
+  class space    used 1069K, capacity 1117K, committed 1152K, reserved 1048576K
+Event: 537.647 GC heap after
+Heap after GC invocations=148 (full 0):
+ PSYoungGen      total 109056K, used 4544K [0x0000000795580000, 0x000000079cc80000, 0x00000007c0000000)
+  eden space 104448K, 0% used [0x0000000795580000,0x0000000795580000,0x000000079bb80000)
+  from space 4608K, 98% used [0x000000079c800000,0x000000079cc70040,0x000000079cc80000)
+  to   space 6144K, 0% used [0x000000079c080000,0x000000079c080000,0x000000079c680000)
+ ParOldGen       total 87552K, used 15778K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 18% used [0x0000000740000000,0x0000000740f68840,0x0000000745580000)
+ Metaspace       used 10465K, capacity 10593K, committed 10880K, reserved 1058816K
+  class space    used 1069K, capacity 1117K, committed 1152K, reserved 1048576K
+}
+Event: 538.072 GC heap before
+{Heap before GC invocations=149 (full 0):
+ PSYoungGen      total 109056K, used 108992K [0x0000000795580000, 0x000000079cc80000, 0x00000007c0000000)
+  eden space 104448K, 100% used [0x0000000795580000,0x000000079bb80000,0x000000079bb80000)
+  from space 4608K, 98% used [0x000000079c800000,0x000000079cc70040,0x000000079cc80000)
+  to   space 6144K, 0% used [0x000000079c080000,0x000000079c080000,0x000000079c680000)
+ ParOldGen       total 87552K, used 15778K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 18% used [0x0000000740000000,0x0000000740f68840,0x0000000745580000)
+ Metaspace       used 10465K, capacity 10593K, committed 10880K, reserved 1058816K
+  class space    used 1069K, capacity 1117K, committed 1152K, reserved 1048576K
+Event: 538.075 GC heap after
+Heap after GC invocations=149 (full 0):
+ PSYoungGen      total 104448K, used 3456K [0x0000000795580000, 0x000000079c880000, 0x00000007c0000000)
+  eden space 100864K, 0% used [0x0000000795580000,0x0000000795580000,0x000000079b800000)
+  from space 3584K, 96% used [0x000000079c080000,0x000000079c3e0030,0x000000079c400000)
+  to   space 4608K, 0% used [0x000000079c400000,0x000000079c400000,0x000000079c880000)
+ ParOldGen       total 87552K, used 15794K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 18% used [0x0000000740000000,0x0000000740f6c840,0x0000000745580000)
+ Metaspace       used 10465K, capacity 10593K, committed 10880K, reserved 1058816K
+  class space    used 1069K, capacity 1117K, committed 1152K, reserved 1048576K
+}
+Event: 538.514 GC heap before
+{Heap before GC invocations=150 (full 0):
+ PSYoungGen      total 104448K, used 104320K [0x0000000795580000, 0x000000079c880000, 0x00000007c0000000)
+  eden space 100864K, 100% used [0x0000000795580000,0x000000079b800000,0x000000079b800000)
+  from space 3584K, 96% used [0x000000079c080000,0x000000079c3e0030,0x000000079c400000)
+  to   space 4608K, 0% used [0x000000079c400000,0x000000079c400000,0x000000079c880000)
+ ParOldGen       total 87552K, used 15794K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 18% used [0x0000000740000000,0x0000000740f6c840,0x0000000745580000)
+ Metaspace       used 10465K, capacity 10593K, committed 10880K, reserved 1058816K
+  class space    used 1069K, capacity 1117K, committed 1152K, reserved 1048576K
+Event: 538.516 GC heap after
+Heap after GC invocations=150 (full 0):
+ PSYoungGen      total 100864K, used 3456K [0x0000000795580000, 0x000000079c780000, 0x00000007c0000000)
+  eden space 97280K, 0% used [0x0000000795580000,0x0000000795580000,0x000000079b480000)
+  from space 3584K, 96% used [0x000000079c400000,0x000000079c760030,0x000000079c780000)
+  to   space 6144K, 0% used [0x000000079bb80000,0x000000079bb80000,0x000000079c180000)
+ ParOldGen       total 87552K, used 15810K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 18% used [0x0000000740000000,0x0000000740f70840,0x0000000745580000)
+ Metaspace       used 10465K, capacity 10593K, committed 10880K, reserved 1058816K
+  class space    used 1069K, capacity 1117K, committed 1152K, reserved 1048576K
+}
+Event: 538.939 GC heap before
+{Heap before GC invocations=151 (full 0):
+ PSYoungGen      total 100864K, used 100736K [0x0000000795580000, 0x000000079c780000, 0x00000007c0000000)
+  eden space 97280K, 100% used [0x0000000795580000,0x000000079b480000,0x000000079b480000)
+  from space 3584K, 96% used [0x000000079c400000,0x000000079c760030,0x000000079c780000)
+  to   space 6144K, 0% used [0x000000079bb80000,0x000000079bb80000,0x000000079c180000)
+ ParOldGen       total 87552K, used 15810K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 18% used [0x0000000740000000,0x0000000740f70840,0x0000000745580000)
+ Metaspace       used 10465K, capacity 10593K, committed 10880K, reserved 1058816K
+  class space    used 1069K, capacity 1117K, committed 1152K, reserved 1048576K
+Event: 538.942 GC heap after
+Heap after GC invocations=151 (full 0):
+ PSYoungGen      total 98304K, used 4512K [0x0000000795580000, 0x000000079c480000, 0x00000007c0000000)
+  eden space 93696K, 0% used [0x0000000795580000,0x0000000795580000,0x000000079b100000)
+  from space 4608K, 97% used [0x000000079bb80000,0x000000079bfe8040,0x000000079c000000)
+  to   space 4608K, 0% used [0x000000079c000000,0x000000079c000000,0x000000079c480000)
+ ParOldGen       total 87552K, used 15826K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 18% used [0x0000000740000000,0x0000000740f74840,0x0000000745580000)
+ Metaspace       used 10465K, capacity 10593K, committed 10880K, reserved 1058816K
+  class space    used 1069K, capacity 1117K, committed 1152K, reserved 1048576K
+}
+
+Deoptimization events (10 events):
+Event: 8.208 Thread 0x00007fd2f2800000 Uncommon trap: reason=class_check action=maybe_recompile pc=0x0000000106d76890 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 253
+Event: 8.209 Thread 0x00007fd2f2800000 Uncommon trap: reason=class_check action=maybe_recompile pc=0x0000000106d76890 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 253
+Event: 8.209 Thread 0x00007fd2f2800000 Uncommon trap: reason=class_check action=maybe_recompile pc=0x0000000106d76890 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 253
+Event: 8.209 Thread 0x00007fd2f2800000 Uncommon trap: reason=class_check action=maybe_recompile pc=0x0000000106d76890 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 253
+Event: 484.983 Thread 0x00007fd2f2800000 Uncommon trap: reason=unreached action=reinterpret pc=0x0000000106ea01fc method=org.newdawn.slick.state.StateBasedGame.render(Lorg/newdawn/slick/GameContainer;Lorg/newdawn/slick/Graphics;)V @ 10
+Event: 485.012 Thread 0x00007fd2f2800000 Uncommon trap: reason=unreached action=reinterpret pc=0x0000000106e82604 method=org.newdawn.slick.state.StateBasedGame.update(Lorg/newdawn/slick/GameContainer;I)V @ 10
+Event: 485.074 Thread 0x00007fd2f2800000 Uncommon trap: reason=unreached action=reinterpret pc=0x0000000106e6a774 method=org.newdawn.slick.opengl.TextureImpl.bind()V @ 4
+Event: 486.789 Thread 0x00007fd2f2800000 Uncommon trap: reason=unloaded action=reinterpret pc=0x0000000106d304b8 method=sun.font.CStrike$GlyphInfoCache.get(I)J @ 58
+Event: 486.884 Thread 0x00007fd2f2800000 Uncommon trap: reason=range_check action=make_not_entrant pc=0x0000000106d31904 method=java.awt.geom.AffineTransform.<init>([D)V @ 7
+Event: 488.081 Thread 0x00007fd2f2800000 Uncommon trap: reason=range_check action=make_not_entrant pc=0x0000000106ed33f4 method=sun.font.CCharToGlyphMapper$Cache.get(I[C[I)V @ 345
+
+Internal exceptions (10 events):
+Event: 7.961 Thread 0x00007fd2f2800000 Exception <a 'java/security/PrivilegedActionException'> (0x0000000795d65b68) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 8.392 Thread 0x00007fd2f2800000 Exception <a 'java/security/PrivilegedActionException'> (0x00000007973cc810) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 8.515 Thread 0x00007fd2f2800000 Exception <a 'java/security/PrivilegedActionException'> (0x00000007967ed788) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 8.531 Thread 0x00007fd2f2800000 Exception <a 'java/security/PrivilegedActionException'> (0x00000007967f5658) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 485.013 Thread 0x00007fd2f2800000 Exception <a 'java/security/PrivilegedActionException'> (0x0000000796093628) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 485.055 Thread 0x00007fd2f2800000 Exception <a 'java/security/PrivilegedActionException'> (0x000000079609a1e0) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 485.056 Thread 0x00007fd2f2800000 Exception <a 'java/security/PrivilegedActionException'> (0x00000007960a5320) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 485.057 Thread 0x00007fd2f2800000 Exception <a 'java/security/PrivilegedActionException'> (0x00000007960aa928) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 488.415 Thread 0x00007fd2f2800000 Exception <a 'java/security/PrivilegedActionException'> (0x0000000798b6c0a8) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 549.899 Thread 0x00007fd2f2800000 Exception <a 'java/security/PrivilegedActionException'> (0x000000079a964010) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+
+Events (10 events):
+Event: 539.941 Thread 0x00007fd2f3831000 flushing nmethod 0x0000000106dd8a90
+Event: 540.112 Thread 0x00007fd2f3831000 flushing nmethod 0x0000000106e98b10
+Event: 540.112 Thread 0x00007fd2f3831000 flushing nmethod 0x0000000106eac3d0
+Event: 540.112 Thread 0x00007fd2f3831000 flushing nmethod 0x0000000106ed2410
+Event: 540.147 Executing VM operation: RevokeBias
+Event: 540.147 Executing VM operation: RevokeBias done
+Event: 540.147 Thread 0x00007fd2f23c5000 Thread exited: 0x00007fd2f23c5000
+Event: 545.175 Thread 0x00007fd2f389b000 Thread added: 0x00007fd2f389b000
+Event: 549.899 loading class org/lwjgl/opengl/CallbackUtil
+Event: 549.899 loading class org/lwjgl/opengl/CallbackUtil done
+
+
+Dynamic libraries:
+0x000000000d140000 	/System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa
+0x000000000d140000 	/System/Library/Frameworks/Security.framework/Versions/A/Security
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices
+0x000000000d140000 	/usr/lib/libz.1.dylib
+0x000000000d140000 	/usr/lib/libSystem.B.dylib
+0x000000000d140000 	/usr/lib/libobjc.A.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
+0x000000000d140000 	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation
+0x000000000d140000 	/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
+0x000000000d140000 	/System/Library/Frameworks/CoreData.framework/Versions/A/CoreData
+0x000000000d140000 	/System/Library/PrivateFrameworks/RemoteViewServices.framework/Versions/A/RemoteViewServices
+0x000000000d140000 	/System/Library/PrivateFrameworks/UIFoundation.framework/Versions/A/UIFoundation
+0x000000000d140000 	/System/Library/Frameworks/IOSurface.framework/Versions/A/IOSurface
+0x000000000d140000 	/System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox
+0x000000000d140000 	/System/Library/Frameworks/AudioUnit.framework/Versions/A/AudioUnit
+0x000000000d140000 	/System/Library/PrivateFrameworks/DataDetectorsCore.framework/Versions/A/DataDetectorsCore
+0x000000000d140000 	/System/Library/PrivateFrameworks/DesktopServicesPriv.framework/Versions/A/DesktopServicesPriv
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/HIToolbox
+0x000000000d140000 	/System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SpeechRecognition.framework/Versions/A/SpeechRecognition
+0x000000000d140000 	/usr/lib/libauto.dylib
+0x000000000d140000 	/usr/lib/libicucore.A.dylib
+0x000000000d140000 	/usr/lib/libxml2.2.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreUI.framework/Versions/A/CoreUI
+0x000000000d140000 	/System/Library/Frameworks/CoreAudio.framework/Versions/A/CoreAudio
+0x000000000d140000 	/System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration
+0x000000000d140000 	/usr/lib/liblangid.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/MultitouchSupport.framework/Versions/A/MultitouchSupport
+0x000000000d140000 	/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
+0x000000000d140000 	/usr/lib/libDiagnosticMessagesClient.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
+0x000000000d140000 	/System/Library/PrivateFrameworks/PerformanceAnalysis.framework/Versions/A/PerformanceAnalysis
+0x000000000d140000 	/System/Library/PrivateFrameworks/GenerationalStorage.framework/Versions/A/GenerationalStorage
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL
+0x000000000d140000 	/System/Library/PrivateFrameworks/Sharing.framework/Versions/A/Sharing
+0x000000000d140000 	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics
+0x000000000d140000 	/System/Library/Frameworks/CoreText.framework/Versions/A/CoreText
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO
+0x000000000d140000 	/usr/lib/libextension.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/Backup.framework/Versions/A/Backup
+0x000000000d140000 	/usr/lib/libarchive.2.dylib
+0x000000000d140000 	/System/Library/Frameworks/CFNetwork.framework/Versions/A/CFNetwork
+0x000000000d140000 	/System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration
+0x000000000d140000 	/usr/lib/libCRFSuite.dylib
+0x000000000d140000 	/usr/lib/libc++.1.dylib
+0x000000000d140000 	/usr/lib/libc++abi.dylib
+0x000000000d140000 	/usr/lib/system/libcache.dylib
+0x000000000d140000 	/usr/lib/system/libcommonCrypto.dylib
+0x000000000d140000 	/usr/lib/system/libcompiler_rt.dylib
+0x000000000d140000 	/usr/lib/system/libcopyfile.dylib
+0x000000000d140000 	/usr/lib/system/libcorecrypto.dylib
+0x000000000d140000 	/usr/lib/system/libdispatch.dylib
+0x000000000d140000 	/usr/lib/system/libdyld.dylib
+0x000000000d140000 	/usr/lib/system/libkeymgr.dylib
+0x000000000d140000 	/usr/lib/system/liblaunch.dylib
+0x000000000d140000 	/usr/lib/system/libmacho.dylib
+0x000000000d140000 	/usr/lib/system/libquarantine.dylib
+0x000000000d140000 	/usr/lib/system/libremovefile.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_asl.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_blocks.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_c.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_configuration.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_coreservices.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_coretls.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_dnssd.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_info.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_kernel.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_m.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_malloc.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_network.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_networkextension.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_notify.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_platform.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_pthread.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_sandbox.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_secinit.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_stats.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_trace.dylib
+0x000000000d140000 	/usr/lib/system/libunc.dylib
+0x000000000d140000 	/usr/lib/system/libunwind.dylib
+0x000000000d140000 	/usr/lib/system/libxpc.dylib
+0x000000000d140000 	/usr/lib/libbz2.1.0.dylib
+0x000000000d140000 	/usr/lib/liblzma.5.dylib
+0x000000000d140000 	/usr/lib/libbsm.0.dylib
+0x000000000d140000 	/usr/lib/libsqlite3.dylib
+0x000000000d140000 	/usr/lib/system/libkxld.dylib
+0x000000000d140000 	/usr/lib/libxar.1.dylib
+0x000000000d140000 	/usr/lib/libpam.2.dylib
+0x000000000d140000 	/usr/lib/libOpenScriptingUtil.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/FSEvents.framework/Versions/A/FSEvents
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/CarbonCore.framework/Versions/A/CarbonCore
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/Metadata.framework/Versions/A/Metadata
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/OSServices.framework/Versions/A/OSServices
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SearchKit.framework/Versions/A/SearchKit
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/AE.framework/Versions/A/AE
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/LaunchServices
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/DictionaryServices.framework/Versions/A/DictionaryServices
+0x000000000d140000 	/System/Library/Frameworks/NetFS.framework/Versions/A/NetFS
+0x000000000d140000 	/System/Library/PrivateFrameworks/NetAuth.framework/Versions/A/NetAuth
+0x000000000d140000 	/System/Library/PrivateFrameworks/login.framework/Versions/A/Frameworks/loginsupport.framework/Versions/A/loginsupport
+0x000000000d140000 	/System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC
+0x000000000d140000 	/usr/lib/libmecabra.dylib
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/ATS
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ColorSync.framework/Versions/A/ColorSync
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/HIServices.framework/Versions/A/HIServices
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/LangAnalysis.framework/Versions/A/LangAnalysis
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/PrintCore.framework/Versions/A/PrintCore
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/QD.framework/Versions/A/QD
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/SpeechSynthesis.framework/Versions/A/SpeechSynthesis
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Accelerate
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vImage.framework/Versions/A/vImage
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/vecLib
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvDSP.dylib
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvMisc.dylib
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLAPACK.dylib
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLinearAlgebra.dylib
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libFontParser.dylib
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libFontRegistry.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/AppleVPA.framework/Versions/A/AppleVPA
+0x000000000d140000 	/System/Library/PrivateFrameworks/AppleJPEG.framework/Versions/A/AppleJPEG
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJPEG.dylib
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libTIFF.dylib
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libPng.dylib
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libGIF.dylib
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJP2.dylib
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libRadiance.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreVideo.framework/Versions/A/CoreVideo
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLU.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGFXShared.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLImage.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCVMSPluginSupport.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCoreVMClient.dylib
+0x000000000d140000 	/usr/lib/libcups.2.dylib
+0x000000000d140000 	/System/Library/Frameworks/Kerberos.framework/Versions/A/Kerberos
+0x000000000d140000 	/System/Library/Frameworks/GSS.framework/Versions/A/GSS
+0x000000000d140000 	/usr/lib/libresolv.9.dylib
+0x000000000d140000 	/usr/lib/libiconv.2.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/Heimdal.framework/Versions/A/Heimdal
+0x000000000d140000 	/usr/lib/libheimdal-asn1.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenDirectory.framework/Versions/A/OpenDirectory
+0x000000000d140000 	/System/Library/PrivateFrameworks/CommonAuth.framework/Versions/A/CommonAuth
+0x000000000d140000 	/System/Library/Frameworks/OpenDirectory.framework/Versions/A/Frameworks/CFOpenDirectory.framework/Versions/A/CFOpenDirectory
+0x000000000d140000 	/System/Library/Frameworks/SecurityFoundation.framework/Versions/A/SecurityFoundation
+0x000000000d140000 	/System/Library/PrivateFrameworks/LanguageModeling.framework/Versions/A/LanguageModeling
+0x000000000d140000 	/usr/lib/libcmph.dylib
+0x000000000d140000 	/System/Library/Frameworks/ServiceManagement.framework/Versions/A/ServiceManagement
+0x000000000d140000 	/usr/lib/libxslt.1.dylib
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Ink.framework/Versions/A/Ink
+0x000000000d140000 	/System/Library/Frameworks/QuartzCore.framework/Versions/A/Frameworks/CoreImage.framework/Versions/A/CoreImage
+0x000000000d140000 	/System/Library/PrivateFrameworks/CrashReporterSupport.framework/Versions/A/CrashReporterSupport
+0x000000000d140000 	/System/Library/Frameworks/OpenCL.framework/Versions/A/OpenCL
+0x000000000d140000 	/System/Library/PrivateFrameworks/FaceCore.framework/Versions/A/FaceCore
+0x000000000d140000 	/System/Library/PrivateFrameworks/Ubiquity.framework/Versions/A/Ubiquity
+0x000000000d140000 	/System/Library/PrivateFrameworks/IconServices.framework/Versions/A/IconServices
+0x000000000d140000 	/System/Library/PrivateFrameworks/ChunkingLibrary.framework/Versions/A/ChunkingLibrary
+0x000000000d140000 	/System/Library/PrivateFrameworks/Apple80211.framework/Versions/A/Apple80211
+0x000000000d140000 	/System/Library/Frameworks/CoreWLAN.framework/Versions/A/CoreWLAN
+0x000000000d140000 	/System/Library/Frameworks/IOBluetooth.framework/Versions/A/IOBluetooth
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreWiFi.framework/Versions/A/CoreWiFi
+0x000000000d140000 	/System/Library/Frameworks/CoreBluetooth.framework/Versions/A/CoreBluetooth
+0x000000000d140000 	/System/Library/PrivateFrameworks/DebugSymbols.framework/Versions/A/DebugSymbols
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/CoreSymbolication
+0x000000000d140000 	/System/Library/PrivateFrameworks/Symbolication.framework/Versions/A/Symbolication
+0x000000000d140000 	/System/Library/PrivateFrameworks/SpeechRecognitionCore.framework/Versions/A/SpeechRecognitionCore
+0x00000001051b1000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/server/libjvm.dylib
+0x000000000d140000 	/usr/lib/libstdc++.6.dylib
+0x00000001061ea000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libverify.dylib
+0x0000000106a00000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libjava.dylib
+0x0000000106a3c000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libzip.dylib
+0x000000011caba000 	/System/Library/Frameworks/JavaVM.framework/Frameworks/JavaRuntimeSupport.framework/JavaRuntimeSupport
+0x000000011cad0000 	/System/Library/Frameworks/JavaVM.framework/Versions/A/Frameworks/JavaNativeFoundation.framework/Versions/A/JavaNativeFoundation
+0x000000011cae4000 	/System/Library/Frameworks/JavaVM.framework/Versions/A/JavaVM
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Carbon
+0x000000011caf0000 	/System/Library/PrivateFrameworks/JavaLaunching.framework/Versions/A/JavaLaunching
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/CommonPanels.framework/Versions/A/CommonPanels
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Help.framework/Versions/A/Help
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/ImageCapture.framework/Versions/A/ImageCapture
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/OpenScripting.framework/Versions/A/OpenScripting
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Print.framework/Versions/A/Print
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SecurityHI.framework/Versions/A/SecurityHI
+0x000000011e8f7000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libawt.dylib
+0x000000011e9a6000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/./libmlib_image.dylib
+0x000000011ea72000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libawt_lwawt.dylib
+0x000000011eb25000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/./libosxapp.dylib
+0x000000000d140000 	/System/Library/Frameworks/ExceptionHandling.framework/Versions/A/ExceptionHandling
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreServicesInternal.framework/Versions/A/CoreServicesInternal
+0x000000000d140000 	/System/Library/PrivateFrameworks/CloudDocs.framework/Versions/A/CloudDocs
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreDuet.framework/Versions/A/CoreDuet
+0x000000000d140000 	/System/Library/Frameworks/CloudKit.framework/Versions/A/CloudKit
+0x000000000d140000 	/System/Library/PrivateFrameworks/ProtocolBuffer.framework/Versions/A/ProtocolBuffer
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreDuetDaemonProtocol.framework/Versions/A/CoreDuetDaemonProtocol
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreDuetDebugLogging.framework/Versions/A/CoreDuetDebugLogging
+0x000000000d140000 	/System/Library/Frameworks/CoreLocation.framework/Versions/A/CoreLocation
+0x000000000d140000 	/System/Library/Frameworks/Accounts.framework/Versions/A/Accounts
+0x000000000d140000 	/System/Library/PrivateFrameworks/ApplePushService.framework/Versions/A/ApplePushService
+0x000000000d140000 	/System/Library/PrivateFrameworks/GeoServices.framework/Versions/A/GeoServices
+0x000000000d140000 	/System/Library/PrivateFrameworks/OAuth.framework/Versions/A/OAuth
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreDaemon.framework/Versions/B/CoreDaemon
+0x000000000d140000 	/usr/lib/libcrypto.0.9.8.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/AppleSRP.framework/Versions/A/AppleSRP
+0x000000000d140000 	/System/Library/PrivateFrameworks/TrustEvaluationAgent.framework/Versions/A/TrustEvaluationAgent
+0x000000000d140000 	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Resources/libCGCMS.A.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Resources/libRIP.A.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Resources/libCGXType.A.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenCL.framework/Versions/A/Libraries/libcldcpuengine.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/DiskImages.framework/Versions/A/DiskImages
+0x000000000d140000 	/System/Library/Frameworks/DiscRecording.framework/Versions/A/DiscRecording
+0x000000000d140000 	/usr/lib/libcsfde.dylib
+0x000000000d140000 	/usr/lib/libcurl.4.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/MediaKit.framework/Versions/A/MediaKit
+0x000000000d140000 	/System/Library/PrivateFrameworks/ProtectedCloudStorage.framework/Versions/A/ProtectedCloudStorage
+0x000000000d140000 	/usr/lib/libCoreStorage.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/EFILogin.framework/Versions/A/EFILogin
+0x000000000d140000 	/usr/lib/libutil.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/FindMyDevice.framework/Versions/A/FindMyDevice
+0x000000000d140000 	/System/Library/Frameworks/LDAP.framework/Versions/A/LDAP
+0x000000000d140000 	/usr/lib/libsasl2.2.dylib
+0x00000001216c5000 	cl_kernels
+0x000000012174a000 	/System/Library/Frameworks/OpenCL.framework/Versions/A/Libraries/ImageFormats/unorm8_bgra.dylib
+0x00000001216b6000 	cl_kernels
+0x000000000d140000 	/System/Library/PrivateFrameworks/FamilyControls.framework/Versions/A/FamilyControls
+0x000000000d140000 	/System/Library/PrivateFrameworks/CommerceKit.framework/Versions/A/Frameworks/CommerceCore.framework/Versions/A/CommerceCore
+0x000000000d140000 	/System/Library/PrivateFrameworks/SystemAdministration.framework/Versions/A/SystemAdministration
+0x000000000d140000 	/System/Library/PrivateFrameworks/AppContainer.framework/Versions/A/AppContainer
+0x000000000d140000 	/System/Library/PrivateFrameworks/SecCodeWrapper.framework/Versions/A/SecCodeWrapper
+0x000000000d140000 	/System/Library/Frameworks/DirectoryService.framework/Versions/A/DirectoryService
+0x000000000d140000 	/System/Library/PrivateFrameworks/LoginUIKit.framework/Versions/A/Frameworks/LoginUICore.framework/Versions/A/LoginUICore
+0x000000000d140000 	/usr/lib/libodfde.dylib
+0x000000012290d000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libfontmanager.dylib
+0x0000000122974000 	/Users/ShantalOlono/Life/slick/liblwjgl.dylib
+0x0000000120bfb000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libjawt.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Resources/GLEngine.bundle/GLEngine
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLProgrammability.dylib
+0x0000000000000000 	/System/Library/Extensions/AppleIntelHD4000GraphicsGLDriver.bundle/Contents/MacOS/AppleIntelHD4000GraphicsGLDriver
+0x000000000d140000 	/System/Library/PrivateFrameworks/IOAccelerator.framework/Versions/A/IOAccelerator
+0x000000000d140000 	/System/Library/PrivateFrameworks/GPUSupport.framework/Versions/A/Libraries/libGPUSupportMercury.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Resources/GLRendererFloat.bundle/GLRendererFloat
+0x00000001231f9000 	/Users/ShantalOlono/Life/slick/libjinput-osx.dylib
+0x00000001231fe000 	/System/Library/Extensions/IOHIDFamily.kext/Contents/PlugIns/IOHIDLib.plugin/Contents/MacOS/IOHIDLib
+0x0000000131399000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libnet.dylib
+0x00000001312df000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libnio.dylib
+
+VM Arguments:
+jvm_args: -Djava.library.path=/Users/ShantalOlono/Life/slick -Dfile.encoding=UTF-8 
+java_command: main.java.edu.asu.cst316.Game
+java_class_path (initial): /Users/ShantalOlono/Life/bin:/Users/ShantalOlono/Life/jar/jacocoagent.jar:/Users/ShantalOlono/Life/jar/jacocoant.jar:/Users/ShantalOlono/Life/jar/junit.jar:/Users/ShantalOlono/Life/jar/org.jacoco.agent-0.7.4.201502262128.jar:/Users/ShantalOlono/Life/jar/org.jacoco.ant-0.7.4.201502262128.jar:/Users/ShantalOlono/Life/jar/org.jacoco.core-0.7.4.201502262128.jar:/Users/ShantalOlono/Life/jar/org.jacoco.report-0.7.4.201502262128.jar:/Users/ShantalOlono/Life/slick/lib/commons-math3-3.3.jar:/Users/ShantalOlono/Life/slick/lib/ibxm.jar:/Users/ShantalOlono/Life/slick/lib/jinput.jar:/Users/ShantalOlono/Life/slick/lib/jnlp.jar:/Users/ShantalOlono/Life/slick/lib/jogg-0.0.7.jar:/Users/ShantalOlono/Life/slick/lib/jorbis-0.0.15.jar:/Users/ShantalOlono/Life/slick/lib/lwjgl_util_applet.jar:/Users/ShantalOlono/Life/slick/lib/lwjgl_util.jar:/Users/ShantalOlono/Life/slick/lib/lwjgl.jar:/Users/ShantalOlono/Life/slick/lib/natives-linux.jar:/Users/ShantalOlono/Life/slick/lib/natives-mac.jar:/Users/ShantalOlono/Life/slick/lib/natives-windows.jar:/Users/ShantalOlono/Life/slick/lib/Pack200Task.jar:/Users/ShantalOlono/Life/slick/lib/slick-examples.jar:/Users/ShantalOlono/Life/slick/lib/slick.jar:/Users/ShantalOlono/Life/slick/lib/tinylinepp.jar
+Launcher Type: SUN_STANDARD
+
+Environment Variables:
+PATH=/usr/bin:/bin:/usr/sbin:/sbin
+SHELL=/bin/bash
+
+Signal Handlers:
+SIGSEGV: [libjvm.dylib+0x57a0e7], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_ONSTACK|SA_RESTART|SA_SIGINFO
+SIGBUS: [libjvm.dylib+0x57a0e7], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGFPE: [libjvm.dylib+0x45af24], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGPIPE: [libjvm.dylib+0x45af24], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGXFSZ: [libjvm.dylib+0x45af24], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGILL: [libjvm.dylib+0x45af24], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGUSR1: SIG_DFL, sa_mask[0]=00000000000000000000000000000000, sa_flags=none
+SIGUSR2: [libjvm.dylib+0x45aa42], sa_mask[0]=00100000000000000000000000000000, sa_flags=SA_RESTART|SA_SIGINFO
+SIGHUP: [libjvm.dylib+0x459015], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGINT: [libjvm.dylib+0x459015], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGTERM: [libjvm.dylib+0x459015], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGQUIT: [libjvm.dylib+0x459015], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+
+
+---------------  S Y S T E M  ---------------
+
+OS:Bsduname:Darwin 14.1.0 Darwin Kernel Version 14.1.0: Mon Dec 22 23:10:38 PST 2014; root:xnu-2782.10.72~2/RELEASE_X86_64 x86_64
+rlimit: STACK 8192k, CORE 0k, NPROC 709, NOFILE 10240, AS infinity
+load average:2.18 1.88 1.99
+
+CPU:total 4 (2 cores per cpu, 2 threads per core) family 6 model 58 stepping 9, cmov, cx8, fxsr, mmx, sse, sse2, sse3, ssse3, sse4.1, sse4.2, popcnt, avx, aes, clmul, erms, ht, tsc, tscinvbit, tscinv
+
+Memory: 4k page, physical 8388608k(1381008k free)
+
+/proc/meminfo:
+
+
+vm_info: Java HotSpot(TM) 64-Bit Server VM (25.31-b07) for bsd-amd64 JRE (1.8.0_31-b13), built on Dec 17 2014 20:45:36 by "java_re" with gcc 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2336.11.00)
+
+time: Mon Apr 20 17:46:09 2015
+elapsed time: 550 seconds (0d 0h 9m 10s)
+

--- a/hs_err_pid9035.log
+++ b/hs_err_pid9035.log
@@ -1,0 +1,620 @@
+#
+# A fatal error has been detected by the Java Runtime Environment:
+#
+#  SIGSEGV (0xb) at pc=0x00007fff97b560dd, pid=9035, tid=1811
+#
+# JRE version: Java(TM) SE Runtime Environment (8.0_31-b13) (build 1.8.0_31-b13)
+# Java VM: Java HotSpot(TM) 64-Bit Server VM (25.31-b07 mixed mode bsd-amd64 compressed oops)
+# Problematic frame:
+# C  [libobjc.A.dylib+0x10dd]  objc_msgSend+0x1d
+#
+# Failed to write core dump. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
+#
+# If you would like to submit a bug report, please visit:
+#   http://bugreport.java.com/bugreport/crash.jsp
+# The crash happened outside the Java Virtual Machine in native code.
+# See problematic frame for where to report the bug.
+#
+
+---------------  T H R E A D  ---------------
+
+Current thread (0x00007f87248af000):  JavaThread "AppKit Thread" daemon [_thread_in_native, id=1811, stack(0x00007fff506f6000,0x00007fff50ef6000)]
+
+siginfo: si_signo: 11 (SIGSEGV), si_code: 1 (SEGV_MAPERR), si_addr: 0x0000000000000018
+
+Registers:
+RAX=0x00007f87237548b0, RBX=0x00007fff50ef1448, RCX=0x0000000000000000, RDX=0x00007f8723589320
+RSP=0x00007fff50ef1268, RBP=0x00007fff50ef1270, RSI=0x00007fff901e02b4, RDI=0x00007f87237548b0
+R8 =0x00007fff50ef1250, R9 =0x0000000000000063, R10=0x00007fff901e02b4, R11=0x0000000000000000
+R12=0x00007f8723506840, R13=0x00000000000f4300, R14=0x00007f87237bed90, R15=0x00007fff50ef13a8
+RIP=0x00007fff97b560dd, EFLAGS=0x0000000000010246, ERR=0x0000000000000004
+  TRAPNO=0x000000000000000e
+
+Top of Stack: (sp=0x00007fff50ef1268)
+0x00007fff50ef1268:   00007fff90a8ecdc 00007fff50ef15d0
+0x00007fff50ef1278:   00007fff90980244 00007fff50ef12fc
+0x00007fff50ef1288:   00007fff50ef1300 00007fff50ef1304
+0x00007fff50ef1298:   00007fff7e5a1c88 ffffffffffffffff
+0x00007fff50ef12a8:   0000000000000948 00007fff7e5a1ca0
+0x00007fff50ef12b8:   00007f87237bed90 0000000000000000
+0x00007fff50ef12c8:   00007fff50ef13a0 0000000000000000
+0x00007fff50ef12d8:   00007f8723755270 00007fff50ef1420
+0x00007fff50ef12e8:   0000000000000063 00000000000f4302
+0x00007fff50ef12f8:   00007f8723589320 00007f8723753f50
+0x00007fff50ef1308:   00007f8723506840 0000000000000001
+0x00007fff50ef1318:   00000000000f4300 00007f8723506830
+0x00007fff50ef1328:   00007fff946047ba 000000017dc46070
+0x00007fff50ef1338:   00007fff7f6e20d0 0000000042000000
+0x00007fff50ef1348:   00007fff9460ce13 00007fff7e56c1d0
+0x00007fff50ef1358:   00007fff50ef1428 0000000000000000
+0x00007fff50ef1368:   00007fff7eb4a8c8 0000000000000000
+0x00007fff50ef1378:   000000000000001d 0004be0397b7697a
+0x00007fff50ef1388:   00007f8723506864 0000000000000000
+0x00007fff50ef1398:   0000000000518901 00007f87237552b0
+0x00007fff50ef13a8:   00007f87237bed90 0000000000000000
+0x00007fff50ef13b8:   00007fff9021834c 00007fff50ef1460
+0x00007fff50ef13c8:   00007fff9b943513 00007fff50ef1444
+0x00007fff50ef13d8:   0000000000518a01 00000000ffffffff
+0x00007fff50ef13e8:   00007fff7eb4a8c8 0000000000518a00
+0x00007fff50ef13f8:   00007fff00000000 00007fff50ef14f0
+0x00007fff50ef1408:   00007fff9ae8fedc 00007fff7eb4a8e8
+0x00007fff50ef1418:   00007fff9021834c 0000000000000051
+0x00007fff50ef1428:   0000000000000000 00000000000f42df
+0x00007fff50ef1438:   0000000000000053 0000000000000000
+0x00007fff50ef1448:   00000000000f4300 00007fff50ef14c4
+0x00007fff50ef1458:   0000000000519401 00000000ffffffff 
+
+Instructions: (pc=0x00007fff97b560dd)
+0x00007fff97b560bd:   00 00 00 48 85 ff 2e 74 7a 40 f6 c7 01 2e 75 7e
+0x00007fff97b560cd:   49 bb f8 ff ff ff ff 7f 00 00 4c 23 1f 49 89 f2
+0x00007fff97b560dd:   45 23 53 18 49 c1 e2 04 4d 03 53 10 49 3b 32 75
+0x00007fff97b560ed:   04 41 ff 62 08 49 83 3a 00 74 6a 4d 3b 53 10 74 
+
+Register to memory mapping:
+
+RAX=0x00007f87237548b0 is an unknown value
+RBX=0x00007fff50ef1448 is pointing into the stack for thread: 0x00007f87248af000
+RCX=0x0000000000000000 is an unknown value
+RDX=0x00007f8723589320 is an unknown value
+RSP=0x00007fff50ef1268 is pointing into the stack for thread: 0x00007f87248af000
+RBP=0x00007fff50ef1270 is pointing into the stack for thread: 0x00007f87248af000
+RSI=0x00007fff901e02b4: -[NSTitlebarContainerView shouldRoundCorners]+0x5ced6 in /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit at 0x00007fff8f80f000
+RDI=0x00007f87237548b0 is an unknown value
+R8 =0x00007fff50ef1250 is pointing into the stack for thread: 0x00007f87248af000
+R9 =0x0000000000000063 is an unknown value
+R10=0x00007fff901e02b4: -[NSTitlebarContainerView shouldRoundCorners]+0x5ced6 in /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit at 0x00007fff8f80f000
+R11=0x0000000000000000 is an unknown value
+R12=0x00007f8723506840 is an unknown value
+R13=0x00000000000f4300 is an unknown value
+R14=0x00007f87237bed90 is an unknown value
+R15=0x00007fff50ef13a8 is pointing into the stack for thread: 0x00007f87248af000
+
+
+Stack: [0x00007fff506f6000,0x00007fff50ef6000],  sp=0x00007fff50ef1268,  free space=8172k
+Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
+C  [libobjc.A.dylib+0x10dd]  objc_msgSend+0x1d
+C  [CoreFoundation+0x10244]  _CFXNotificationPost+0xc44
+C  [Foundation+0x2c31]  -[NSNotificationCenter postNotificationName:object:userInfo:]+0x42
+C  [AppKit+0xdd776]  -[NSSurface _disposeSurface]+0x98
+C  [AppKit+0xdd1da]  -[NSSurface setWindow:]+0x42
+C  [AppKit+0x3b9ef]  -[NSView _setWindow:]+0xa22
+C  [AppKit+0x3cc22]  -[NSView removeFromSuperview]+0x1c5
+C  [AppKit+0x9140a]  -[NSView removeFromSuperviewWithoutNeedingDisplay]+0x26
+C  [liblwjgl.dylib+0xa205]  +[MacOSXKeyableWindow destroyWindow]+0xb5
+C  [Foundation+0x65cdc]  __NSThreadPerformPerform+0x125
+C  [CoreFoundation+0x80681]  __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__+0x11
+C  [CoreFoundation+0x7280d]  __CFRunLoopDoSources0+0x10d
+C  [CoreFoundation+0x71e3f]  __CFRunLoopRun+0x39f
+C  [CoreFoundation+0x71858]  CFRunLoopRunSpecific+0x128
+C  [HIToolbox+0x2eaef]  RunCurrentEventLoopInMode+0xeb
+C  [HIToolbox+0x2e76e]  ReceiveNextEventCommon+0xb3
+C  [HIToolbox+0x2e6ab]  _BlockUntilNextEventMatchingListInModeWithFilter+0x47
+C  [AppKit+0x23f81]  _DPSNextEvent+0x3c4
+C  [AppKit+0x23730]  -[NSApplication nextEventMatchingMask:untilDate:inMode:dequeue:]+0xc2
+C  [libosxapp.dylib+0x242a]  -[NSApplicationAWT nextEventMatchingMask:untilDate:inMode:dequeue:]+0x7c
+C  [AppKit+0x17593]  -[NSApplication run]+0x252
+C  [libosxapp.dylib+0x223e]  +[NSApplicationAWT runAWTLoopWithApp:]+0x9c
+C  [libawt_lwawt.dylib+0x4494f]  -[AWTStarter starter:]+0x389
+C  [Foundation+0x65cdc]  __NSThreadPerformPerform+0x125
+C  [CoreFoundation+0x80681]  __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__+0x11
+C  [CoreFoundation+0x7280d]  __CFRunLoopDoSources0+0x10d
+C  [CoreFoundation+0x71e3f]  __CFRunLoopRun+0x39f
+C  [CoreFoundation+0x71858]  CFRunLoopRunSpecific+0x128
+C  [java+0x56cc]  CreateExecutionEnvironment+0x367
+C  [java+0x165c]  JLI_Launch+0x7a0
+C  [java+0x768a]  main+0x65
+C  [java+0xeb4]  start+0x34
+C  0x0000000000000006
+
+
+---------------  P R O C E S S  ---------------
+
+Java Threads: ( => current thread )
+  0x00007f872487d800 JavaThread "AWT-Shutdown" [_thread_blocked, id=28975, stack(0x000000013c9fe000,0x000000013cafe000)]
+  0x00007f8723a5c000 JavaThread "Java2D Disposer" daemon [_thread_blocked, id=49511, stack(0x000000013ae3b000,0x000000013af3b000)]
+  0x00007f872499e000 JavaThread "Java2D Queue Flusher" daemon [_thread_blocked, id=60167, stack(0x000000013a4ef000,0x000000013a5ef000)]
+=>0x00007f87248af000 JavaThread "AppKit Thread" daemon [_thread_in_native, id=1811, stack(0x00007fff506f6000,0x00007fff50ef6000)]
+  0x00007f8723853800 JavaThread "Service Thread" daemon [_thread_blocked, id=18179, stack(0x000000012835d000,0x000000012845d000)]
+  0x00007f8724017800 JavaThread "C1 CompilerThread2" daemon [_thread_blocked, id=17667, stack(0x000000012825a000,0x000000012835a000)]
+  0x00007f8724017000 JavaThread "C2 CompilerThread1" daemon [_thread_blocked, id=17155, stack(0x0000000128157000,0x0000000128257000)]
+  0x00007f872380b800 JavaThread "C2 CompilerThread0" daemon [_thread_blocked, id=16643, stack(0x0000000128054000,0x0000000128154000)]
+  0x00007f872400f800 JavaThread "Signal Dispatcher" daemon [_thread_blocked, id=16159, stack(0x0000000127f51000,0x0000000128051000)]
+  0x00007f8724830800 JavaThread "Finalizer" daemon [_thread_blocked, id=11523, stack(0x0000000126626000,0x0000000126726000)]
+  0x00007f8724830000 JavaThread "Reference Handler" daemon [_thread_blocked, id=11011, stack(0x0000000126523000,0x0000000126623000)]
+  0x00007f8724806000 JavaThread "main" [_thread_in_native, id=4867, stack(0x0000000110601000,0x0000000110701000)]
+
+Other Threads:
+  0x00007f8725028800 VMThread [stack: 0x0000000126420000,0x0000000126520000] [id=10499]
+  0x00007f8723816800 WatcherThread [stack: 0x0000000128460000,0x0000000128560000] [id=18691]
+
+VM state:not at safepoint (normal execution)
+
+VM Mutex/Monitor currently owned by a thread: None
+
+Heap:
+ PSYoungGen      total 177152K, used 176736K [0x0000000795580000, 0x00000007aa380000, 0x00000007c0000000)
+  eden space 171008K, 100% used [0x0000000795580000,0x000000079fc80000,0x000000079fc80000)
+  from space 6144K, 93% used [0x00000007a9d80000,0x00000007aa318050,0x00000007aa380000)
+  to   space 8192K, 0% used [0x00000007a9380000,0x00000007a9380000,0x00000007a9b80000)
+ ParOldGen       total 87552K, used 9705K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 11% used [0x0000000740000000,0x000000074097a700,0x0000000745580000)
+ Metaspace       used 10349K, capacity 10517K, committed 10624K, reserved 1058816K
+  class space    used 1070K, capacity 1117K, committed 1152K, reserved 1048576K
+
+Card table byte_map: [0x000000011fac3000,0x000000011fec4000] byte_map_base: 0x000000011c0c3000
+
+Marking Bits: (ParMarkBitMap*) 0x000000010f6a6410
+ Begin Bits: [0x000000012057b000, 0x000000012257b000)
+ End Bits:   [0x000000012257b000, 0x000000012457b000)
+
+Polling page: 0x000000010fd80000
+
+CodeCache: size=245760Kb used=4988Kb max_used=4988Kb free=240771Kb
+ bounds [0x0000000110703000, 0x0000000110bf3000, 0x000000011f703000]
+ total_blobs=1862 nmethods=1334 adapters=443
+ compilation: enabled
+
+Compilation events (10 events):
+Event: 23.205 Thread 0x00007f8724017800 1337       3       org.newdawn.slick.state.StateBasedGame::inputStarted (1 bytes)
+Event: 23.205 Thread 0x00007f8724017800 nmethod 1337 0x0000000110be3dd0 code [0x0000000110be3f20, 0x0000000110be4070]
+Event: 23.205 Thread 0x00007f8724017800 1338       3       org.newdawn.slick.Graphics::resetFont (8 bytes)
+Event: 23.205 Thread 0x00007f8724017800 nmethod 1338 0x0000000110be4110 code [0x0000000110be4280, 0x0000000110be4410]
+Event: 23.205 Thread 0x00007f8724017800 1339       3       org.newdawn.slick.state.StateBasedGame::postRenderState (1 bytes)
+Event: 23.205 Thread 0x00007f8724017800 nmethod 1339 0x0000000110be4490 code [0x0000000110be45e0, 0x0000000110be4730]
+Event: 23.230 Thread 0x00007f8724017800 1340       3       org.newdawn.slick.state.StateBasedGame::preUpdateState (1 bytes)
+Event: 23.231 Thread 0x00007f8724017800 nmethod 1340 0x0000000110be47d0 code [0x0000000110be4920, 0x0000000110be4a70]
+Event: 23.231 Thread 0x00007f8724017800 1341       3       org.newdawn.slick.state.StateBasedGame::postUpdateState (1 bytes)
+Event: 23.231 Thread 0x00007f8724017800 nmethod 1341 0x0000000110be4b10 code [0x0000000110be4c60, 0x0000000110be4db0]
+
+GC Heap History (10 events):
+Event: 13.790 GC heap before
+{Heap before GC invocations=12 (full 0):
+ PSYoungGen      total 219136K, used 217808K [0x0000000795580000, 0x00000007ab080000, 0x00000007c0000000)
+  eden space 210944K, 100% used [0x0000000795580000,0x00000007a2380000,0x00000007a2380000)
+  from space 8192K, 83% used [0x00000007a2380000,0x00000007a2a34070,0x00000007a2b80000)
+  to   space 8704K, 0% used [0x00000007aa800000,0x00000007aa800000,0x00000007ab080000)
+ ParOldGen       total 87552K, used 9433K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 10% used [0x0000000740000000,0x00000007409366f0,0x0000000745580000)
+ Metaspace       used 10195K, capacity 10325K, committed 10368K, reserved 1058816K
+  class space    used 1070K, capacity 1117K, committed 1152K, reserved 1048576K
+Event: 13.796 GC heap after
+Heap after GC invocations=12 (full 0):
+ PSYoungGen      total 208384K, used 5824K [0x0000000795580000, 0x00000007aae00000, 0x00000007c0000000)
+  eden space 202240K, 0% used [0x0000000795580000,0x0000000795580000,0x00000007a1b00000)
+  from space 6144K, 94% used [0x00000007aa800000,0x00000007aadb0050,0x00000007aae00000)
+  to   space 8192K, 0% used [0x00000007a9e00000,0x00000007a9e00000,0x00000007aa600000)
+ ParOldGen       total 87552K, used 9497K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 10% used [0x0000000740000000,0x0000000740946700,0x0000000745580000)
+ Metaspace       used 10195K, capacity 10325K, committed 10368K, reserved 1058816K
+  class space    used 1070K, capacity 1117K, committed 1152K, reserved 1048576K
+}
+Event: 14.776 GC heap before
+{Heap before GC invocations=13 (full 0):
+ PSYoungGen      total 208384K, used 208064K [0x0000000795580000, 0x00000007aae00000, 0x00000007c0000000)
+  eden space 202240K, 100% used [0x0000000795580000,0x00000007a1b00000,0x00000007a1b00000)
+  from space 6144K, 94% used [0x00000007aa800000,0x00000007aadb0050,0x00000007aae00000)
+  to   space 8192K, 0% used [0x00000007a9e00000,0x00000007a9e00000,0x00000007aa600000)
+ ParOldGen       total 87552K, used 9497K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 10% used [0x0000000740000000,0x0000000740946700,0x0000000745580000)
+ Metaspace       used 10209K, capacity 10389K, committed 10624K, reserved 1058816K
+  class space    used 1070K, capacity 1117K, committed 1152K, reserved 1048576K
+Event: 14.783 GC heap after
+Heap after GC invocations=13 (full 0):
+ PSYoungGen      total 201216K, used 6816K [0x0000000795580000, 0x00000007aa880000, 0x00000007c0000000)
+  eden space 194048K, 0% used [0x0000000795580000,0x0000000795580000,0x00000007a1300000)
+  from space 7168K, 95% used [0x00000007a9e00000,0x00000007aa4a8060,0x00000007aa500000)
+  to   space 3584K, 0% used [0x00000007aa500000,0x00000007aa500000,0x00000007aa880000)
+ ParOldGen       total 87552K, used 9521K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 10% used [0x0000000740000000,0x000000074094c700,0x0000000745580000)
+ Metaspace       used 10209K, capacity 10389K, committed 10624K, reserved 1058816K
+  class space    used 1070K, capacity 1117K, committed 1152K, reserved 1048576K
+}
+Event: 15.695 GC heap before
+{Heap before GC invocations=14 (full 0):
+ PSYoungGen      total 201216K, used 200864K [0x0000000795580000, 0x00000007aa880000, 0x00000007c0000000)
+  eden space 194048K, 100% used [0x0000000795580000,0x00000007a1300000,0x00000007a1300000)
+  from space 7168K, 95% used [0x00000007a9e00000,0x00000007aa4a8060,0x00000007aa500000)
+  to   space 3584K, 0% used [0x00000007aa500000,0x00000007aa500000,0x00000007aa880000)
+ ParOldGen       total 87552K, used 9521K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 10% used [0x0000000740000000,0x000000074094c700,0x0000000745580000)
+ Metaspace       used 10216K, capacity 10389K, committed 10624K, reserved 1058816K
+  class space    used 1070K, capacity 1117K, committed 1152K, reserved 1048576K
+Event: 15.699 GC heap after
+Heap after GC invocations=14 (full 0):
+ PSYoungGen      total 189440K, used 3552K [0x0000000795580000, 0x00000007aa880000, 0x00000007c0000000)
+  eden space 185856K, 0% used [0x0000000795580000,0x0000000795580000,0x00000007a0b00000)
+  from space 3584K, 99% used [0x00000007aa500000,0x00000007aa878030,0x00000007aa880000)
+  to   space 8704K, 0% used [0x00000007a9780000,0x00000007a9780000,0x00000007aa000000)
+ ParOldGen       total 87552K, used 9673K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 11% used [0x0000000740000000,0x0000000740972700,0x0000000745580000)
+ Metaspace       used 10216K, capacity 10389K, committed 10624K, reserved 1058816K
+  class space    used 1070K, capacity 1117K, committed 1152K, reserved 1048576K
+}
+Event: 16.557 GC heap before
+{Heap before GC invocations=15 (full 0):
+ PSYoungGen      total 189440K, used 189408K [0x0000000795580000, 0x00000007aa880000, 0x00000007c0000000)
+  eden space 185856K, 100% used [0x0000000795580000,0x00000007a0b00000,0x00000007a0b00000)
+  from space 3584K, 99% used [0x00000007aa500000,0x00000007aa878030,0x00000007aa880000)
+  to   space 8704K, 0% used [0x00000007a9780000,0x00000007a9780000,0x00000007aa000000)
+ ParOldGen       total 87552K, used 9673K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 11% used [0x0000000740000000,0x0000000740972700,0x0000000745580000)
+ Metaspace       used 10220K, capacity 10389K, committed 10624K, reserved 1058816K
+  class space    used 1070K, capacity 1117K, committed 1152K, reserved 1048576K
+Event: 16.564 GC heap after
+Heap after GC invocations=15 (full 0):
+ PSYoungGen      total 184320K, used 5728K [0x0000000795580000, 0x00000007aa580000, 0x00000007c0000000)
+  eden space 178176K, 0% used [0x0000000795580000,0x0000000795580000,0x00000007a0380000)
+  from space 6144K, 93% used [0x00000007a9780000,0x00000007a9d18050,0x00000007a9d80000)
+  to   space 8192K, 0% used [0x00000007a9d80000,0x00000007a9d80000,0x00000007aa580000)
+ ParOldGen       total 87552K, used 9697K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 11% used [0x0000000740000000,0x0000000740978700,0x0000000745580000)
+ Metaspace       used 10220K, capacity 10389K, committed 10624K, reserved 1058816K
+  class space    used 1070K, capacity 1117K, committed 1152K, reserved 1048576K
+}
+Event: 17.538 GC heap before
+{Heap before GC invocations=16 (full 0):
+ PSYoungGen      total 184320K, used 183904K [0x0000000795580000, 0x00000007aa580000, 0x00000007c0000000)
+  eden space 178176K, 100% used [0x0000000795580000,0x00000007a0380000,0x00000007a0380000)
+  from space 6144K, 93% used [0x00000007a9780000,0x00000007a9d18050,0x00000007a9d80000)
+  to   space 8192K, 0% used [0x00000007a9d80000,0x00000007a9d80000,0x00000007aa580000)
+ ParOldGen       total 87552K, used 9697K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 11% used [0x0000000740000000,0x0000000740978700,0x0000000745580000)
+ Metaspace       used 10229K, capacity 10389K, committed 10624K, reserved 1058816K
+  class space    used 1070K, capacity 1117K, committed 1152K, reserved 1048576K
+Event: 17.543 GC heap after
+Heap after GC invocations=16 (full 0):
+ PSYoungGen      total 177152K, used 5728K [0x0000000795580000, 0x00000007aa380000, 0x00000007c0000000)
+  eden space 171008K, 0% used [0x0000000795580000,0x0000000795580000,0x000000079fc80000)
+  from space 6144K, 93% used [0x00000007a9d80000,0x00000007aa318050,0x00000007aa380000)
+  to   space 8192K, 0% used [0x00000007a9380000,0x00000007a9380000,0x00000007a9b80000)
+ ParOldGen       total 87552K, used 9705K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 11% used [0x0000000740000000,0x000000074097a700,0x0000000745580000)
+ Metaspace       used 10229K, capacity 10389K, committed 10624K, reserved 1058816K
+  class space    used 1070K, capacity 1117K, committed 1152K, reserved 1048576K
+}
+
+Deoptimization events (10 events):
+Event: 4.879 Thread 0x00007f8724806000 Uncommon trap: reason=bimorphic action=maybe_recompile pc=0x00000001109199c0 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 91
+Event: 4.879 Thread 0x00007f8724806000 Uncommon trap: reason=bimorphic action=maybe_recompile pc=0x00000001109199c0 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 91
+Event: 4.880 Thread 0x00007f8724806000 Uncommon trap: reason=bimorphic action=maybe_recompile pc=0x0000000110911e64 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 91
+Event: 7.519 Thread 0x00007f8724806000 Uncommon trap: reason=class_check action=maybe_recompile pc=0x00000001109825d8 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 253
+Event: 7.519 Thread 0x00007f8724806000 Uncommon trap: reason=class_check action=maybe_recompile pc=0x00000001109825d8 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 253
+Event: 7.519 Thread 0x00007f8724806000 Uncommon trap: reason=class_check action=maybe_recompile pc=0x00000001109825d8 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 253
+Event: 7.519 Thread 0x00007f8724806000 Uncommon trap: reason=class_check action=maybe_recompile pc=0x00000001109825d8 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 253
+Event: 10.737 Thread 0x00007f8724806000 Uncommon trap: reason=unloaded action=reinterpret pc=0x0000000110ada878 method=sun.font.CStrike$GlyphInfoCache.get(I)J @ 58
+Event: 10.865 Thread 0x00007f8724806000 Uncommon trap: reason=range_check action=make_not_entrant pc=0x0000000110adbb44 method=java.awt.geom.AffineTransform.<init>([D)V @ 7
+Event: 12.329 Thread 0x00007f8724806000 Uncommon trap: reason=range_check action=make_not_entrant pc=0x0000000110b24134 method=sun.font.CCharToGlyphMapper$Cache.get(I[C[I)V @ 345
+
+Internal exceptions (10 events):
+Event: 7.398 Thread 0x00007f8724806000 Exception <a 'java/security/PrivilegedActionException'> (0x0000000795cbf3b8) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 7.642 Thread 0x00007f8724806000 Exception <a 'java/security/PrivilegedActionException'> (0x0000000797325fa0) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 7.824 Thread 0x00007f8724806000 Exception <a 'java/security/PrivilegedActionException'> (0x00000007967a1750) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 7.828 Thread 0x00007f8724806000 Exception <a 'java/security/PrivilegedActionException'> (0x00000007967a9620) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 8.563 Thread 0x00007f8724806000 Exception <a 'java/security/PrivilegedActionException'> (0x00000007968e32e8) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 8.563 Thread 0x00007f8724806000 Exception <a 'java/security/PrivilegedActionException'> (0x00000007968e9ea0) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 8.565 Thread 0x00007f8724806000 Exception <a 'java/security/PrivilegedActionException'> (0x00000007968f4fe0) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 8.566 Thread 0x00007f8724806000 Exception <a 'java/security/PrivilegedActionException'> (0x00000007968fa5e8) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 12.198 Thread 0x00007f8724806000 Exception <a 'java/security/PrivilegedActionException'> (0x000000079cb6a870) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 23.268 Thread 0x00007f8724806000 Exception <a 'java/security/PrivilegedActionException'> (0x000000079fa9cdd0) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+
+Events (10 events):
+Event: 17.552 Executing VM operation: RevokeBias
+Event: 17.552 Executing VM operation: RevokeBias done
+Event: 17.552 Executing VM operation: RevokeBias
+Event: 17.553 Executing VM operation: RevokeBias done
+Event: 20.824 Executing VM operation: RevokeBias
+Event: 20.824 Executing VM operation: RevokeBias done
+Event: 20.824 Thread 0x00007f872512f800 Thread exited: 0x00007f872512f800
+Event: 21.513 Thread 0x00007f872487d800 Thread added: 0x00007f872487d800
+Event: 23.268 loading class org/lwjgl/opengl/CallbackUtil
+Event: 23.268 loading class org/lwjgl/opengl/CallbackUtil done
+
+
+Dynamic libraries:
+0x000000000d140000 	/System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa
+0x000000000d140000 	/System/Library/Frameworks/Security.framework/Versions/A/Security
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices
+0x000000000d140000 	/usr/lib/libz.1.dylib
+0x000000000d140000 	/usr/lib/libSystem.B.dylib
+0x000000000d140000 	/usr/lib/libobjc.A.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
+0x000000000d140000 	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation
+0x000000000d140000 	/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
+0x000000000d140000 	/System/Library/Frameworks/CoreData.framework/Versions/A/CoreData
+0x000000000d140000 	/System/Library/PrivateFrameworks/RemoteViewServices.framework/Versions/A/RemoteViewServices
+0x000000000d140000 	/System/Library/PrivateFrameworks/UIFoundation.framework/Versions/A/UIFoundation
+0x000000000d140000 	/System/Library/Frameworks/IOSurface.framework/Versions/A/IOSurface
+0x000000000d140000 	/System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox
+0x000000000d140000 	/System/Library/Frameworks/AudioUnit.framework/Versions/A/AudioUnit
+0x000000000d140000 	/System/Library/PrivateFrameworks/DataDetectorsCore.framework/Versions/A/DataDetectorsCore
+0x000000000d140000 	/System/Library/PrivateFrameworks/DesktopServicesPriv.framework/Versions/A/DesktopServicesPriv
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/HIToolbox
+0x000000000d140000 	/System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SpeechRecognition.framework/Versions/A/SpeechRecognition
+0x000000000d140000 	/usr/lib/libauto.dylib
+0x000000000d140000 	/usr/lib/libicucore.A.dylib
+0x000000000d140000 	/usr/lib/libxml2.2.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreUI.framework/Versions/A/CoreUI
+0x000000000d140000 	/System/Library/Frameworks/CoreAudio.framework/Versions/A/CoreAudio
+0x000000000d140000 	/System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration
+0x000000000d140000 	/usr/lib/liblangid.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/MultitouchSupport.framework/Versions/A/MultitouchSupport
+0x000000000d140000 	/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
+0x000000000d140000 	/usr/lib/libDiagnosticMessagesClient.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
+0x000000000d140000 	/System/Library/PrivateFrameworks/PerformanceAnalysis.framework/Versions/A/PerformanceAnalysis
+0x000000000d140000 	/System/Library/PrivateFrameworks/GenerationalStorage.framework/Versions/A/GenerationalStorage
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL
+0x000000000d140000 	/System/Library/PrivateFrameworks/Sharing.framework/Versions/A/Sharing
+0x000000000d140000 	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics
+0x000000000d140000 	/System/Library/Frameworks/CoreText.framework/Versions/A/CoreText
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO
+0x000000000d140000 	/usr/lib/libextension.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/Backup.framework/Versions/A/Backup
+0x000000000d140000 	/usr/lib/libarchive.2.dylib
+0x000000000d140000 	/System/Library/Frameworks/CFNetwork.framework/Versions/A/CFNetwork
+0x000000000d140000 	/System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration
+0x000000000d140000 	/usr/lib/libCRFSuite.dylib
+0x000000000d140000 	/usr/lib/libc++.1.dylib
+0x000000000d140000 	/usr/lib/libc++abi.dylib
+0x000000000d140000 	/usr/lib/system/libcache.dylib
+0x000000000d140000 	/usr/lib/system/libcommonCrypto.dylib
+0x000000000d140000 	/usr/lib/system/libcompiler_rt.dylib
+0x000000000d140000 	/usr/lib/system/libcopyfile.dylib
+0x000000000d140000 	/usr/lib/system/libcorecrypto.dylib
+0x000000000d140000 	/usr/lib/system/libdispatch.dylib
+0x000000000d140000 	/usr/lib/system/libdyld.dylib
+0x000000000d140000 	/usr/lib/system/libkeymgr.dylib
+0x000000000d140000 	/usr/lib/system/liblaunch.dylib
+0x000000000d140000 	/usr/lib/system/libmacho.dylib
+0x000000000d140000 	/usr/lib/system/libquarantine.dylib
+0x000000000d140000 	/usr/lib/system/libremovefile.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_asl.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_blocks.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_c.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_configuration.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_coreservices.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_coretls.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_dnssd.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_info.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_kernel.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_m.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_malloc.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_network.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_networkextension.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_notify.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_platform.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_pthread.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_sandbox.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_secinit.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_stats.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_trace.dylib
+0x000000000d140000 	/usr/lib/system/libunc.dylib
+0x000000000d140000 	/usr/lib/system/libunwind.dylib
+0x000000000d140000 	/usr/lib/system/libxpc.dylib
+0x000000000d140000 	/usr/lib/libbz2.1.0.dylib
+0x000000000d140000 	/usr/lib/liblzma.5.dylib
+0x000000000d140000 	/usr/lib/libbsm.0.dylib
+0x000000000d140000 	/usr/lib/libsqlite3.dylib
+0x000000000d140000 	/usr/lib/system/libkxld.dylib
+0x000000000d140000 	/usr/lib/libxar.1.dylib
+0x000000000d140000 	/usr/lib/libpam.2.dylib
+0x000000000d140000 	/usr/lib/libOpenScriptingUtil.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/FSEvents.framework/Versions/A/FSEvents
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/CarbonCore.framework/Versions/A/CarbonCore
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/Metadata.framework/Versions/A/Metadata
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/OSServices.framework/Versions/A/OSServices
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SearchKit.framework/Versions/A/SearchKit
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/AE.framework/Versions/A/AE
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/LaunchServices
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/DictionaryServices.framework/Versions/A/DictionaryServices
+0x000000000d140000 	/System/Library/Frameworks/NetFS.framework/Versions/A/NetFS
+0x000000000d140000 	/System/Library/PrivateFrameworks/NetAuth.framework/Versions/A/NetAuth
+0x000000000d140000 	/System/Library/PrivateFrameworks/login.framework/Versions/A/Frameworks/loginsupport.framework/Versions/A/loginsupport
+0x000000000d140000 	/System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC
+0x000000000d140000 	/usr/lib/libmecabra.dylib
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/ATS
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ColorSync.framework/Versions/A/ColorSync
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/HIServices.framework/Versions/A/HIServices
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/LangAnalysis.framework/Versions/A/LangAnalysis
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/PrintCore.framework/Versions/A/PrintCore
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/QD.framework/Versions/A/QD
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/SpeechSynthesis.framework/Versions/A/SpeechSynthesis
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Accelerate
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vImage.framework/Versions/A/vImage
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/vecLib
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvDSP.dylib
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvMisc.dylib
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLAPACK.dylib
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLinearAlgebra.dylib
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libFontParser.dylib
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libFontRegistry.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/AppleVPA.framework/Versions/A/AppleVPA
+0x000000000d140000 	/System/Library/PrivateFrameworks/AppleJPEG.framework/Versions/A/AppleJPEG
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJPEG.dylib
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libTIFF.dylib
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libPng.dylib
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libGIF.dylib
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJP2.dylib
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libRadiance.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreVideo.framework/Versions/A/CoreVideo
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLU.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGFXShared.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLImage.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCVMSPluginSupport.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCoreVMClient.dylib
+0x000000000d140000 	/usr/lib/libcups.2.dylib
+0x000000000d140000 	/System/Library/Frameworks/Kerberos.framework/Versions/A/Kerberos
+0x000000000d140000 	/System/Library/Frameworks/GSS.framework/Versions/A/GSS
+0x000000000d140000 	/usr/lib/libresolv.9.dylib
+0x000000000d140000 	/usr/lib/libiconv.2.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/Heimdal.framework/Versions/A/Heimdal
+0x000000000d140000 	/usr/lib/libheimdal-asn1.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenDirectory.framework/Versions/A/OpenDirectory
+0x000000000d140000 	/System/Library/PrivateFrameworks/CommonAuth.framework/Versions/A/CommonAuth
+0x000000000d140000 	/System/Library/Frameworks/OpenDirectory.framework/Versions/A/Frameworks/CFOpenDirectory.framework/Versions/A/CFOpenDirectory
+0x000000000d140000 	/System/Library/Frameworks/SecurityFoundation.framework/Versions/A/SecurityFoundation
+0x000000000d140000 	/System/Library/PrivateFrameworks/LanguageModeling.framework/Versions/A/LanguageModeling
+0x000000000d140000 	/usr/lib/libcmph.dylib
+0x000000000d140000 	/System/Library/Frameworks/ServiceManagement.framework/Versions/A/ServiceManagement
+0x000000000d140000 	/usr/lib/libxslt.1.dylib
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Ink.framework/Versions/A/Ink
+0x000000000d140000 	/System/Library/Frameworks/QuartzCore.framework/Versions/A/Frameworks/CoreImage.framework/Versions/A/CoreImage
+0x000000000d140000 	/System/Library/PrivateFrameworks/CrashReporterSupport.framework/Versions/A/CrashReporterSupport
+0x000000000d140000 	/System/Library/Frameworks/OpenCL.framework/Versions/A/OpenCL
+0x000000000d140000 	/System/Library/PrivateFrameworks/FaceCore.framework/Versions/A/FaceCore
+0x000000000d140000 	/System/Library/PrivateFrameworks/Ubiquity.framework/Versions/A/Ubiquity
+0x000000000d140000 	/System/Library/PrivateFrameworks/IconServices.framework/Versions/A/IconServices
+0x000000000d140000 	/System/Library/PrivateFrameworks/ChunkingLibrary.framework/Versions/A/ChunkingLibrary
+0x000000000d140000 	/System/Library/PrivateFrameworks/Apple80211.framework/Versions/A/Apple80211
+0x000000000d140000 	/System/Library/Frameworks/CoreWLAN.framework/Versions/A/CoreWLAN
+0x000000000d140000 	/System/Library/Frameworks/IOBluetooth.framework/Versions/A/IOBluetooth
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreWiFi.framework/Versions/A/CoreWiFi
+0x000000000d140000 	/System/Library/Frameworks/CoreBluetooth.framework/Versions/A/CoreBluetooth
+0x000000000d140000 	/System/Library/PrivateFrameworks/DebugSymbols.framework/Versions/A/DebugSymbols
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/CoreSymbolication
+0x000000000d140000 	/System/Library/PrivateFrameworks/Symbolication.framework/Versions/A/Symbolication
+0x000000000d140000 	/System/Library/PrivateFrameworks/SpeechRecognitionCore.framework/Versions/A/SpeechRecognitionCore
+0x000000010ee08000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/server/libjvm.dylib
+0x000000000d140000 	/usr/lib/libstdc++.6.dylib
+0x000000010fd3e000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libverify.dylib
+0x000000010fd4c000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libjava.dylib
+0x000000010fd8a000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libzip.dylib
+0x000000010fde4000 	/System/Library/Frameworks/JavaVM.framework/Frameworks/JavaRuntimeSupport.framework/JavaRuntimeSupport
+0x0000000126728000 	/System/Library/Frameworks/JavaVM.framework/Versions/A/Frameworks/JavaNativeFoundation.framework/Versions/A/JavaNativeFoundation
+0x000000012673c000 	/System/Library/Frameworks/JavaVM.framework/Versions/A/JavaVM
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Carbon
+0x0000000126748000 	/System/Library/PrivateFrameworks/JavaLaunching.framework/Versions/A/JavaLaunching
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/CommonPanels.framework/Versions/A/CommonPanels
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Help.framework/Versions/A/Help
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/ImageCapture.framework/Versions/A/ImageCapture
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/OpenScripting.framework/Versions/A/OpenScripting
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Print.framework/Versions/A/Print
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SecurityHI.framework/Versions/A/SecurityHI
+0x00000001285d1000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libawt.dylib
+0x0000000128680000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/./libmlib_image.dylib
+0x000000012874c000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libawt_lwawt.dylib
+0x00000001287ff000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/./libosxapp.dylib
+0x000000000d140000 	/System/Library/Frameworks/ExceptionHandling.framework/Versions/A/ExceptionHandling
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreServicesInternal.framework/Versions/A/CoreServicesInternal
+0x000000000d140000 	/System/Library/PrivateFrameworks/CloudDocs.framework/Versions/A/CloudDocs
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreDuet.framework/Versions/A/CoreDuet
+0x000000000d140000 	/System/Library/Frameworks/CloudKit.framework/Versions/A/CloudKit
+0x000000000d140000 	/System/Library/PrivateFrameworks/ProtocolBuffer.framework/Versions/A/ProtocolBuffer
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreDuetDaemonProtocol.framework/Versions/A/CoreDuetDaemonProtocol
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreDuetDebugLogging.framework/Versions/A/CoreDuetDebugLogging
+0x000000000d140000 	/System/Library/Frameworks/CoreLocation.framework/Versions/A/CoreLocation
+0x000000000d140000 	/System/Library/Frameworks/Accounts.framework/Versions/A/Accounts
+0x000000000d140000 	/System/Library/PrivateFrameworks/ApplePushService.framework/Versions/A/ApplePushService
+0x000000000d140000 	/System/Library/PrivateFrameworks/GeoServices.framework/Versions/A/GeoServices
+0x000000000d140000 	/System/Library/PrivateFrameworks/OAuth.framework/Versions/A/OAuth
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreDaemon.framework/Versions/B/CoreDaemon
+0x000000000d140000 	/usr/lib/libcrypto.0.9.8.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/AppleSRP.framework/Versions/A/AppleSRP
+0x000000000d140000 	/System/Library/PrivateFrameworks/TrustEvaluationAgent.framework/Versions/A/TrustEvaluationAgent
+0x000000000d140000 	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Resources/libCGCMS.A.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Resources/libRIP.A.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Resources/libCGXType.A.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenCL.framework/Versions/A/Libraries/libcldcpuengine.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/DiskImages.framework/Versions/A/DiskImages
+0x000000000d140000 	/System/Library/Frameworks/DiscRecording.framework/Versions/A/DiscRecording
+0x000000000d140000 	/usr/lib/libcsfde.dylib
+0x000000000d140000 	/usr/lib/libcurl.4.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/MediaKit.framework/Versions/A/MediaKit
+0x000000000d140000 	/System/Library/PrivateFrameworks/ProtectedCloudStorage.framework/Versions/A/ProtectedCloudStorage
+0x000000000d140000 	/usr/lib/libCoreStorage.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/EFILogin.framework/Versions/A/EFILogin
+0x000000000d140000 	/usr/lib/libutil.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/FindMyDevice.framework/Versions/A/FindMyDevice
+0x000000000d140000 	/System/Library/Frameworks/LDAP.framework/Versions/A/LDAP
+0x000000000d140000 	/usr/lib/libsasl2.2.dylib
+0x000000012b39f000 	cl_kernels
+0x000000012b3a1000 	/System/Library/Frameworks/OpenCL.framework/Versions/A/Libraries/ImageFormats/unorm8_bgra.dylib
+0x000000012b390000 	cl_kernels
+0x000000000d140000 	/System/Library/PrivateFrameworks/FamilyControls.framework/Versions/A/FamilyControls
+0x000000000d140000 	/System/Library/PrivateFrameworks/CommerceKit.framework/Versions/A/Frameworks/CommerceCore.framework/Versions/A/CommerceCore
+0x000000000d140000 	/System/Library/PrivateFrameworks/SystemAdministration.framework/Versions/A/SystemAdministration
+0x000000000d140000 	/System/Library/PrivateFrameworks/AppContainer.framework/Versions/A/AppContainer
+0x000000000d140000 	/System/Library/PrivateFrameworks/SecCodeWrapper.framework/Versions/A/SecCodeWrapper
+0x000000000d140000 	/System/Library/Frameworks/DirectoryService.framework/Versions/A/DirectoryService
+0x000000000d140000 	/System/Library/PrivateFrameworks/LoginUIKit.framework/Versions/A/Frameworks/LoginUICore.framework/Versions/A/LoginUICore
+0x000000000d140000 	/usr/lib/libodfde.dylib
+0x000000012c5e7000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libfontmanager.dylib
+0x000000012c64e000 	/Users/ShantalOlono/Life/slick/liblwjgl.dylib
+0x000000012a8d6000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libjawt.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Resources/GLEngine.bundle/GLEngine
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLProgrammability.dylib
+0x0000000000000000 	/System/Library/Extensions/AppleIntelHD4000GraphicsGLDriver.bundle/Contents/MacOS/AppleIntelHD4000GraphicsGLDriver
+0x000000000d140000 	/System/Library/PrivateFrameworks/IOAccelerator.framework/Versions/A/IOAccelerator
+0x000000000d140000 	/System/Library/PrivateFrameworks/GPUSupport.framework/Versions/A/Libraries/libGPUSupportMercury.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Resources/GLRendererFloat.bundle/GLRendererFloat
+0x000000012ce84000 	/Users/ShantalOlono/Life/slick/libjinput-osx.dylib
+0x000000012ce89000 	/System/Library/Extensions/IOHIDFamily.kext/Contents/PlugIns/IOHIDLib.plugin/Contents/MacOS/IOHIDLib
+0x000000013b00b000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libnet.dylib
+0x000000013af51000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libnio.dylib
+
+VM Arguments:
+jvm_args: -Djava.library.path=/Users/ShantalOlono/Life/slick -Dfile.encoding=UTF-8 
+java_command: main.java.edu.asu.cst316.Game
+java_class_path (initial): /Users/ShantalOlono/Life/bin:/Users/ShantalOlono/Life/jar/jacocoagent.jar:/Users/ShantalOlono/Life/jar/jacocoant.jar:/Users/ShantalOlono/Life/jar/junit.jar:/Users/ShantalOlono/Life/jar/org.jacoco.agent-0.7.4.201502262128.jar:/Users/ShantalOlono/Life/jar/org.jacoco.ant-0.7.4.201502262128.jar:/Users/ShantalOlono/Life/jar/org.jacoco.core-0.7.4.201502262128.jar:/Users/ShantalOlono/Life/jar/org.jacoco.report-0.7.4.201502262128.jar:/Users/ShantalOlono/Life/slick/lib/commons-math3-3.3.jar:/Users/ShantalOlono/Life/slick/lib/ibxm.jar:/Users/ShantalOlono/Life/slick/lib/jinput.jar:/Users/ShantalOlono/Life/slick/lib/jnlp.jar:/Users/ShantalOlono/Life/slick/lib/jogg-0.0.7.jar:/Users/ShantalOlono/Life/slick/lib/jorbis-0.0.15.jar:/Users/ShantalOlono/Life/slick/lib/lwjgl_util_applet.jar:/Users/ShantalOlono/Life/slick/lib/lwjgl_util.jar:/Users/ShantalOlono/Life/slick/lib/lwjgl.jar:/Users/ShantalOlono/Life/slick/lib/natives-linux.jar:/Users/ShantalOlono/Life/slick/lib/natives-mac.jar:/Users/ShantalOlono/Life/slick/lib/natives-windows.jar:/Users/ShantalOlono/Life/slick/lib/Pack200Task.jar:/Users/ShantalOlono/Life/slick/lib/slick-examples.jar:/Users/ShantalOlono/Life/slick/lib/slick.jar:/Users/ShantalOlono/Life/slick/lib/tinylinepp.jar
+Launcher Type: SUN_STANDARD
+
+Environment Variables:
+PATH=/usr/bin:/bin:/usr/sbin:/sbin
+SHELL=/bin/bash
+
+Signal Handlers:
+SIGSEGV: [libjvm.dylib+0x57a0e7], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_ONSTACK|SA_RESTART|SA_SIGINFO
+SIGBUS: [libjvm.dylib+0x57a0e7], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGFPE: [libjvm.dylib+0x45af24], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGPIPE: [libjvm.dylib+0x45af24], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGXFSZ: [libjvm.dylib+0x45af24], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGILL: [libjvm.dylib+0x45af24], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGUSR1: SIG_DFL, sa_mask[0]=00000000000000000000000000000000, sa_flags=none
+SIGUSR2: [libjvm.dylib+0x45aa42], sa_mask[0]=00100000000000000000000000000000, sa_flags=SA_RESTART|SA_SIGINFO
+SIGHUP: [libjvm.dylib+0x459015], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGINT: [libjvm.dylib+0x459015], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGTERM: [libjvm.dylib+0x459015], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGQUIT: [libjvm.dylib+0x459015], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+
+
+---------------  S Y S T E M  ---------------
+
+OS:Bsduname:Darwin 14.1.0 Darwin Kernel Version 14.1.0: Mon Dec 22 23:10:38 PST 2014; root:xnu-2782.10.72~2/RELEASE_X86_64 x86_64
+rlimit: STACK 8192k, CORE 0k, NPROC 709, NOFILE 10240, AS infinity
+load average:2.58 2.34 2.12
+
+CPU:total 4 (2 cores per cpu, 2 threads per core) family 6 model 58 stepping 9, cmov, cx8, fxsr, mmx, sse, sse2, sse3, ssse3, sse4.1, sse4.2, popcnt, avx, aes, clmul, erms, ht, tsc, tscinvbit, tscinv
+
+Memory: 4k page, physical 8388608k(426424k free)
+
+/proc/meminfo:
+
+
+vm_info: Java HotSpot(TM) 64-Bit Server VM (25.31-b07) for bsd-amd64 JRE (1.8.0_31-b13), built on Dec 17 2014 20:45:36 by "java_re" with gcc 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2336.11.00)
+
+time: Mon Apr 20 18:09:47 2015
+elapsed time: 23 seconds (0d 0h 0m 23s)
+

--- a/hs_err_pid9041.log
+++ b/hs_err_pid9041.log
@@ -1,0 +1,617 @@
+#
+# A fatal error has been detected by the Java Runtime Environment:
+#
+#  SIGSEGV (0xb) at pc=0x00007fff97b560dd, pid=9041, tid=1811
+#
+# JRE version: Java(TM) SE Runtime Environment (8.0_31-b13) (build 1.8.0_31-b13)
+# Java VM: Java HotSpot(TM) 64-Bit Server VM (25.31-b07 mixed mode bsd-amd64 compressed oops)
+# Problematic frame:
+# C  [libobjc.A.dylib+0x10dd]  objc_msgSend+0x1d
+#
+# Failed to write core dump. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
+#
+# If you would like to submit a bug report, please visit:
+#   http://bugreport.java.com/bugreport/crash.jsp
+# The crash happened outside the Java Virtual Machine in native code.
+# See problematic frame for where to report the bug.
+#
+
+---------------  T H R E A D  ---------------
+
+Current thread (0x00007fc8820f8800):  JavaThread "AppKit Thread" daemon [_thread_in_native, id=1811, stack(0x00007fff54c4a000,0x00007fff5544a000)]
+
+siginfo: si_signo: 11 (SIGSEGV), si_code: 1 (SEGV_MAPERR), si_addr: 0x0000000000000018
+
+Registers:
+RAX=0x0000000000000000, RBX=0x00007fc881e70ba0, RCX=0x0000000000000000, RDX=0x00007fc881e70ba0
+RSP=0x00007fff55444808, RBP=0x00007fff55444830, RSI=0x00007fff901e0212, RDI=0x00007fc881d5d3a0
+R8 =0x0000000000000001, R9 =0x0000000000000001, R10=0x00007fff901e0212, R11=0x0000000000000000
+R12=0x0000000000000094, R13=0x00007fc881c39d80, R14=0x00007fc881d5d3a0, R15=0x00007fff55444d20
+RIP=0x00007fff97b560dd, EFLAGS=0x0000000000010246, ERR=0x0000000000000004
+  TRAPNO=0x000000000000000e
+
+Top of Stack: (sp=0x00007fff55444808)
+0x00007fff55444808:   00000001280de598 00007fc881e70ba0
+0x00007fff55444818:   0000000128112c60 00007fc881c39d80
+0x00007fff55444828:   00007fc881e70ba0 00007fff55444d10
+0x00007fff55444838:   00007fff8f95d3c5 0000000000000000
+0x00007fff55444848:   0000000000000000 4089000000000000
+0x00007fff55444858:   4082c00000000000 0000000000000000
+0x00007fff55444868:   0000000000000000 4089000000000000
+0x00007fff55444878:   4082c00000000000 4089000000000000
+0x00007fff55444888:   4083700000000000 401c000000000000
+0x00007fff55444898:   4082d80000000000 402c000000000000
+0x00007fff554448a8:   4030000000000000 401c000000000000
+0x00007fff554448b8:   0000000000000000 0000000000000000
+0x00007fff554448c8:   4030000000000000 00007fff901a412a
+0x00007fff554448d8:   4008000000000000 00007fc881d52fe0
+0x00007fff554448e8:   0000000100000000 0000000000000000
+0x00007fff554448f8:   00007fc881d2f690 00007fff55444a50
+0x00007fff55444908:   00007fff8fa232b6 00007fff55444a50
+0x00007fff55444918:   00007fff8fa23da2 402c000000000000
+0x00007fff55444928:   4030000000000000 401c000000000000
+0x00007fff55444938:   4082d80000000000 402c000000000000
+0x00007fff55444948:   4030000000000000 0000000000000000
+0x00007fff55444958:   0000000000000000 4089000000000000
+0x00007fff55444968:   4083700000000000 401c000000000000
+0x00007fff55444978:   4082d80000000000 402c000000000000
+0x00007fff55444988:   4030000000000000 0000000000000000
+0x00007fff55444998:   0000000000000000 000000010a7d4e00
+0x00007fff554449a8:   000000010a7d0000 00007fff55444a50
+0x00007fff554449b8:   00007fff9ae934ff 00000000000006d4
+0x00007fff554449c8:   000000010a7d0000 00007fff55444a70
+0x00007fff554449d8:   00007fff9ae934ff 00007fff55444adf
+0x00007fff554449e8:   0000000000000000 00007fc8845fc080
+0x00007fff554449f8:   00007fc88458c600 000000000000000b 
+
+Instructions: (pc=0x00007fff97b560dd)
+0x00007fff97b560bd:   00 00 00 48 85 ff 2e 74 7a 40 f6 c7 01 2e 75 7e
+0x00007fff97b560cd:   49 bb f8 ff ff ff ff 7f 00 00 4c 23 1f 49 89 f2
+0x00007fff97b560dd:   45 23 53 18 49 c1 e2 04 4d 03 53 10 49 3b 32 75
+0x00007fff97b560ed:   04 41 ff 62 08 49 83 3a 00 74 6a 4d 3b 53 10 74 
+
+Register to memory mapping:
+
+RAX=0x0000000000000000 is an unknown value
+RBX=0x00007fc881e70ba0 is an unknown value
+RCX=0x0000000000000000 is an unknown value
+RDX=0x00007fc881e70ba0 is an unknown value
+RSP=0x00007fff55444808 is pointing into the stack for thread: 0x00007fc8820f8800
+RBP=0x00007fff55444830 is pointing into the stack for thread: 0x00007fc8820f8800
+RSI=0x00007fff901e0212: -[NSTitlebarContainerView shouldRoundCorners]+0x5ce34 in /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit at 0x00007fff8f80f000
+RDI=0x00007fc881d5d3a0 is an unknown value
+R8 =0x0000000000000001 is an unknown value
+R9 =0x0000000000000001 is an unknown value
+R10=0x00007fff901e0212: -[NSTitlebarContainerView shouldRoundCorners]+0x5ce34 in /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit at 0x00007fff8f80f000
+R11=0x0000000000000000 is an unknown value
+R12=0x0000000000000094 is an unknown value
+R13=0x00007fc881c39d80 is an unknown value
+R14=0x00007fc881d5d3a0 is an unknown value
+R15=0x00007fff55444d20 is pointing into the stack for thread: 0x00007fc8820f8800
+
+
+Stack: [0x00007fff54c4a000,0x00007fff5544a000],  sp=0x00007fff55444808,  free space=8170k
+Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
+C  [libobjc.A.dylib+0x10dd]  objc_msgSend+0x1d
+C  [AppKit+0x14e3c5]  -[NSView _recursiveDisplayRectIfNeededIgnoringOpacity:isVisibleRect:rectIsVisibleRectForView:topView:]+0x740
+C  [AppKit+0x14f420]  -[NSView _recursiveDisplayRectIfNeededIgnoringOpacity:isVisibleRect:rectIsVisibleRectForView:topView:]+0x179b
+C  [AppKit+0x14d773]  -[NSThemeFrame _recursiveDisplayRectIfNeededIgnoringOpacity:isVisibleRect:rectIsVisibleRectForView:topView:]+0x14d
+C  [AppKit+0x14a2cb]  -[NSView _displayRectIgnoringOpacity:isVisibleRect:rectIsVisibleRectForView:]+0xac9
+C  [AppKit+0x128e2d]  -[NSView displayIfNeeded]+0x754
+C  [AppKit+0x1461c5]  -[NSWindow displayIfNeeded]+0xe8
+C  [AppKit+0x183322]  _handleWindowNeedsDisplayOrLayoutOrUpdateConstraints+0x3a8
+C  [AppKit+0x74c0e1]  __83-[NSWindow _postWindowNeedsDisplayOrLayoutOrUpdateConstraintsUnlessPostingDisabled]_block_invoke1531+0x2e
+C  [CoreFoundation+0x7fda7]  __CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__+0x17
+C  [CoreFoundation+0x7fd00]  __CFRunLoopDoObservers+0x170
+C  [CoreFoundation+0x71e08]  __CFRunLoopRun+0x368
+C  [CoreFoundation+0x71858]  CFRunLoopRunSpecific+0x128
+C  [HIToolbox+0x2eaef]  RunCurrentEventLoopInMode+0xeb
+C  [HIToolbox+0x2e76e]  ReceiveNextEventCommon+0xb3
+C  [HIToolbox+0x2e6ab]  _BlockUntilNextEventMatchingListInModeWithFilter+0x47
+C  [AppKit+0x23f81]  _DPSNextEvent+0x3c4
+C  [AppKit+0x23730]  -[NSApplication nextEventMatchingMask:untilDate:inMode:dequeue:]+0xc2
+C  [libosxapp.dylib+0x242a]  -[NSApplicationAWT nextEventMatchingMask:untilDate:inMode:dequeue:]+0x7c
+C  [AppKit+0x17593]  -[NSApplication run]+0x252
+C  [libosxapp.dylib+0x223e]  +[NSApplicationAWT runAWTLoopWithApp:]+0x9c
+C  [libawt_lwawt.dylib+0x4494f]  -[AWTStarter starter:]+0x389
+C  [Foundation+0x65cdc]  __NSThreadPerformPerform+0x125
+C  [CoreFoundation+0x80681]  __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__+0x11
+C  [CoreFoundation+0x7280d]  __CFRunLoopDoSources0+0x10d
+C  [CoreFoundation+0x71e3f]  __CFRunLoopRun+0x39f
+C  [CoreFoundation+0x71858]  CFRunLoopRunSpecific+0x128
+C  [java+0x56cc]  CreateExecutionEnvironment+0x367
+C  [java+0x165c]  JLI_Launch+0x7a0
+C  [java+0x768a]  main+0x65
+C  [java+0xeb4]  start+0x34
+C  0x0000000000000006
+
+
+---------------  P R O C E S S  ---------------
+
+Java Threads: ( => current thread )
+  0x00007fc883c79800 JavaThread "AWT-Shutdown" [_thread_blocked, id=23843, stack(0x00000001331c2000,0x00000001332c2000)]
+  0x00007fc883921000 JavaThread "Java2D Disposer" daemon [_thread_blocked, id=48803, stack(0x0000000136957000,0x0000000136a57000)]
+  0x00007fc8821fc000 JavaThread "Java2D Queue Flusher" daemon [_thread_blocked, id=60167, stack(0x0000000135fba000,0x00000001360ba000)]
+=>0x00007fc8820f8800 JavaThread "AppKit Thread" daemon [_thread_in_native, id=1811, stack(0x00007fff54c4a000,0x00007fff5544a000)]
+  0x00007fc883067000 JavaThread "Service Thread" daemon [_thread_blocked, id=18179, stack(0x0000000123e08000,0x0000000123f08000)]
+  0x00007fc883054800 JavaThread "C1 CompilerThread2" daemon [_thread_blocked, id=17667, stack(0x0000000123d05000,0x0000000123e05000)]
+  0x00007fc883053800 JavaThread "C2 CompilerThread1" daemon [_thread_blocked, id=17155, stack(0x0000000123c02000,0x0000000123d02000)]
+  0x00007fc883022000 JavaThread "C2 CompilerThread0" daemon [_thread_blocked, id=16643, stack(0x0000000123aff000,0x0000000123bff000)]
+  0x00007fc88380b800 JavaThread "Signal Dispatcher" daemon [_thread_blocked, id=12811, stack(0x00000001239fc000,0x0000000123afc000)]
+  0x00007fc883010000 JavaThread "Finalizer" daemon [_thread_blocked, id=11523, stack(0x00000001220bb000,0x00000001221bb000)]
+  0x00007fc883801800 JavaThread "Reference Handler" daemon [_thread_blocked, id=11011, stack(0x0000000121fb8000,0x00000001220b8000)]
+  0x00007fc882808000 JavaThread "main" [_thread_in_native, id=4867, stack(0x000000010c001000,0x000000010c101000)]
+
+Other Threads:
+  0x00007fc883801000 VMThread [stack: 0x0000000121eb5000,0x0000000121fb5000] [id=10499]
+  0x00007fc883068000 WatcherThread [stack: 0x0000000123f0b000,0x000000012400b000] [id=18691]
+
+VM state:not at safepoint (normal execution)
+
+VM Mutex/Monitor currently owned by a thread: None
+
+Heap:
+ PSYoungGen      total 344064K, used 295978K [0x0000000795580000, 0x00000007ab180000, 0x00000007c0000000)
+  eden space 333312K, 88% used [0x0000000795580000,0x00000007a75f28f8,0x00000007a9b00000)
+  from space 10752K, 5% used [0x00000007aa600000,0x00000007aa698000,0x00000007ab080000)
+  to   space 11264K, 0% used [0x00000007a9b00000,0x00000007a9b00000,0x00000007aa600000)
+ ParOldGen       total 87552K, used 17584K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 20% used [0x0000000740000000,0x000000074112c3b8,0x0000000745580000)
+ Metaspace       used 10389K, capacity 10529K, committed 10624K, reserved 1058816K
+  class space    used 1070K, capacity 1117K, committed 1152K, reserved 1048576K
+
+Card table byte_map: [0x000000011b508000,0x000000011b909000] byte_map_base: 0x0000000117b08000
+
+Marking Bits: (ParMarkBitMap*) 0x000000010b152410
+ Begin Bits: [0x000000011bfc0000, 0x000000011dfc0000)
+ End Bits:   [0x000000011dfc0000, 0x000000011ffc0000)
+
+Polling page: 0x000000010b7f8000
+
+CodeCache: size=245760Kb used=5224Kb max_used=5238Kb free=240535Kb
+ bounds [0x000000010c148000, 0x000000010c678000, 0x000000011b148000]
+ total_blobs=1893 nmethods=1365 adapters=443
+ compilation: enabled
+
+Compilation events (10 events):
+Event: 25.753 Thread 0x00007fc883022000 nmethod 1373 0x000000010c6589d0 code [0x000000010c658b60, 0x000000010c659028]
+Event: 25.810 Thread 0x00007fc883053800 nmethod 1372 0x000000010c665110 code [0x000000010c6656c0, 0x000000010c6695f8]
+Event: 25.849 Thread 0x00007fc883022000 1374       4       java.io.UnixFileSystem::getBooleanAttributes (49 bytes)
+Event: 25.859 Thread 0x00007fc883022000 nmethod 1374 0x000000010c662850 code [0x000000010c6629e0, 0x000000010c662f38]
+Event: 25.987 Thread 0x00007fc883053800 1375       4       java.io.File::exists (43 bytes)
+Event: 26.001 Thread 0x00007fc883053800 nmethod 1375 0x000000010c6640d0 code [0x000000010c6642a0, 0x000000010c6649b8]
+Event: 26.042 Thread 0x00007fc883022000 1376       4       java.io.UnixFileSystem::resolve (103 bytes)
+Event: 26.049 Thread 0x00007fc883022000 nmethod 1376 0x000000010c65fb50 code [0x000000010c65fd00, 0x000000010c660578]
+Event: 26.076 Thread 0x00007fc883053800 1377       4       java.io.File::<init> (113 bytes)
+Event: 26.084 Thread 0x00007fc883053800 nmethod 1377 0x000000010c663590 code [0x000000010c663740, 0x000000010c663c80]
+
+GC Heap History (10 events):
+Event: 9.256 GC heap before
+{Heap before GC invocations=8 (full 0):
+ PSYoungGen      total 76800K, used 70944K [0x0000000795580000, 0x000000079ea80000, 0x00000007c0000000)
+  eden space 65536K, 100% used [0x0000000795580000,0x0000000799580000,0x0000000799580000)
+  from space 11264K, 48% used [0x0000000799580000,0x0000000799ac8050,0x000000079a080000)
+  to   space 10752K, 0% used [0x000000079e000000,0x000000079e000000,0x000000079ea80000)
+ ParOldGen       total 87552K, used 14360K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 16% used [0x0000000740000000,0x0000000740e06378,0x0000000745580000)
+ Metaspace       used 10179K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1068K, capacity 1117K, committed 1152K, reserved 1048576K
+Event: 9.259 GC heap after
+Heap after GC invocations=8 (full 0):
+ PSYoungGen      total 141312K, used 3424K [0x0000000795580000, 0x000000079eb80000, 0x00000007c0000000)
+  eden space 130560K, 0% used [0x0000000795580000,0x0000000795580000,0x000000079d500000)
+  from space 10752K, 31% used [0x000000079e000000,0x000000079e358030,0x000000079ea80000)
+  to   space 11264K, 0% used [0x000000079d500000,0x000000079d500000,0x000000079e000000)
+ ParOldGen       total 87552K, used 14384K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 16% used [0x0000000740000000,0x0000000740e0c378,0x0000000745580000)
+ Metaspace       used 10179K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1068K, capacity 1117K, committed 1152K, reserved 1048576K
+}
+Event: 9.935 GC heap before
+{Heap before GC invocations=9 (full 0):
+ PSYoungGen      total 141312K, used 133984K [0x0000000795580000, 0x000000079eb80000, 0x00000007c0000000)
+  eden space 130560K, 100% used [0x0000000795580000,0x000000079d500000,0x000000079d500000)
+  from space 10752K, 31% used [0x000000079e000000,0x000000079e358030,0x000000079ea80000)
+  to   space 11264K, 0% used [0x000000079d500000,0x000000079d500000,0x000000079e000000)
+ ParOldGen       total 87552K, used 14384K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 16% used [0x0000000740000000,0x0000000740e0c378,0x0000000745580000)
+ Metaspace       used 10185K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1068K, capacity 1117K, committed 1152K, reserved 1048576K
+Event: 9.940 GC heap after
+Heap after GC invocations=9 (full 0):
+ PSYoungGen      total 141824K, used 7648K [0x0000000795580000, 0x00000007a3780000, 0x00000007c0000000)
+  eden space 130560K, 0% used [0x0000000795580000,0x0000000795580000,0x000000079d500000)
+  from space 11264K, 67% used [0x000000079d500000,0x000000079dc78070,0x000000079e000000)
+  to   space 11264K, 0% used [0x00000007a2c80000,0x00000007a2c80000,0x00000007a3780000)
+ ParOldGen       total 87552K, used 14392K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 16% used [0x0000000740000000,0x0000000740e0e378,0x0000000745580000)
+ Metaspace       used 10185K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1068K, capacity 1117K, committed 1152K, reserved 1048576K
+}
+Event: 10.667 GC heap before
+{Heap before GC invocations=10 (full 0):
+ PSYoungGen      total 141824K, used 138208K [0x0000000795580000, 0x00000007a3780000, 0x00000007c0000000)
+  eden space 130560K, 100% used [0x0000000795580000,0x000000079d500000,0x000000079d500000)
+  from space 11264K, 67% used [0x000000079d500000,0x000000079dc78070,0x000000079e000000)
+  to   space 11264K, 0% used [0x00000007a2c80000,0x00000007a2c80000,0x00000007a3780000)
+ ParOldGen       total 87552K, used 14392K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 16% used [0x0000000740000000,0x0000000740e0e378,0x0000000745580000)
+ Metaspace       used 10195K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1068K, capacity 1117K, committed 1152K, reserved 1048576K
+Event: 10.671 GC heap after
+Heap after GC invocations=10 (full 0):
+ PSYoungGen      total 219648K, used 1504K [0x0000000795580000, 0x00000007a3880000, 0x00000007c0000000)
+  eden space 208384K, 0% used [0x0000000795580000,0x0000000795580000,0x00000007a2100000)
+  from space 11264K, 13% used [0x00000007a2c80000,0x00000007a2df8010,0x00000007a3780000)
+  to   space 11776K, 0% used [0x00000007a2100000,0x00000007a2100000,0x00000007a2c80000)
+ ParOldGen       total 87552K, used 14408K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 16% used [0x0000000740000000,0x0000000740e12378,0x0000000745580000)
+ Metaspace       used 10195K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1068K, capacity 1117K, committed 1152K, reserved 1048576K
+}
+Event: 11.759 GC heap before
+{Heap before GC invocations=11 (full 0):
+ PSYoungGen      total 219648K, used 209888K [0x0000000795580000, 0x00000007a3880000, 0x00000007c0000000)
+  eden space 208384K, 100% used [0x0000000795580000,0x00000007a2100000,0x00000007a2100000)
+  from space 11264K, 13% used [0x00000007a2c80000,0x00000007a2df8010,0x00000007a3780000)
+  to   space 11776K, 0% used [0x00000007a2100000,0x00000007a2100000,0x00000007a2c80000)
+ ParOldGen       total 87552K, used 14408K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 16% used [0x0000000740000000,0x0000000740e12378,0x0000000745580000)
+ Metaspace       used 10200K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1068K, capacity 1117K, committed 1152K, reserved 1048576K
+Event: 11.765 GC heap after
+Heap after GC invocations=11 (full 0):
+ PSYoungGen      total 220160K, used 5840K [0x0000000795580000, 0x00000007ab080000, 0x00000007c0000000)
+  eden space 208384K, 0% used [0x0000000795580000,0x0000000795580000,0x00000007a2100000)
+  from space 11776K, 49% used [0x00000007a2100000,0x00000007a26b4060,0x00000007a2c80000)
+  to   space 10752K, 0% used [0x00000007aa600000,0x00000007aa600000,0x00000007ab080000)
+ ParOldGen       total 87552K, used 14432K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 16% used [0x0000000740000000,0x0000000740e18378,0x0000000745580000)
+ Metaspace       used 10200K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1068K, capacity 1117K, committed 1152K, reserved 1048576K
+}
+Event: 12.674 GC heap before
+{Heap before GC invocations=12 (full 0):
+ PSYoungGen      total 220160K, used 214224K [0x0000000795580000, 0x00000007ab080000, 0x00000007c0000000)
+  eden space 208384K, 100% used [0x0000000795580000,0x00000007a2100000,0x00000007a2100000)
+  from space 11776K, 49% used [0x00000007a2100000,0x00000007a26b4060,0x00000007a2c80000)
+  to   space 10752K, 0% used [0x00000007aa600000,0x00000007aa600000,0x00000007ab080000)
+ ParOldGen       total 87552K, used 14432K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 16% used [0x0000000740000000,0x0000000740e18378,0x0000000745580000)
+ Metaspace       used 10204K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1068K, capacity 1117K, committed 1152K, reserved 1048576K
+Event: 12.678 GC heap after
+Heap after GC invocations=12 (full 0):
+ PSYoungGen      total 344064K, used 608K [0x0000000795580000, 0x00000007ab180000, 0x00000007c0000000)
+  eden space 333312K, 0% used [0x0000000795580000,0x0000000795580000,0x00000007a9b00000)
+  from space 10752K, 5% used [0x00000007aa600000,0x00000007aa698000,0x00000007ab080000)
+  to   space 11264K, 0% used [0x00000007a9b00000,0x00000007a9b00000,0x00000007aa600000)
+ ParOldGen       total 87552K, used 17584K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 20% used [0x0000000740000000,0x000000074112c3b8,0x0000000745580000)
+ Metaspace       used 10204K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1068K, capacity 1117K, committed 1152K, reserved 1048576K
+}
+
+Deoptimization events (8 events):
+Event: 4.356 Thread 0x00007fc882808000 Uncommon trap: reason=bimorphic action=maybe_recompile pc=0x000000010c366a00 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 91
+Event: 4.356 Thread 0x00007fc882808000 Uncommon trap: reason=bimorphic action=maybe_recompile pc=0x000000010c366a00 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 91
+Event: 4.356 Thread 0x00007fc882808000 Uncommon trap: reason=bimorphic action=maybe_recompile pc=0x000000010c366a00 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 91
+Event: 4.357 Thread 0x00007fc882808000 Uncommon trap: reason=bimorphic action=maybe_recompile pc=0x000000010c366a00 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 91
+Event: 4.357 Thread 0x00007fc882808000 Uncommon trap: reason=bimorphic action=maybe_recompile pc=0x000000010c368064 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 91
+Event: 9.874 Thread 0x00007fc882808000 Uncommon trap: reason=unloaded action=reinterpret pc=0x000000010c531cf8 method=sun.font.CStrike$GlyphInfoCache.get(I)J @ 58
+Event: 9.984 Thread 0x00007fc882808000 Uncommon trap: reason=range_check action=make_not_entrant pc=0x000000010c535484 method=java.awt.geom.AffineTransform.<init>([D)V @ 7
+Event: 11.390 Thread 0x00007fc882808000 Uncommon trap: reason=range_check action=make_not_entrant pc=0x000000010c579434 method=sun.font.CCharToGlyphMapper$Cache.get(I[C[I)V @ 345
+
+Internal exceptions (10 events):
+Event: 6.673 Thread 0x00007fc882808000 Exception <a 'java/security/PrivilegedActionException'> (0x0000000795d65b50) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 6.926 Thread 0x00007fc882808000 Exception <a 'java/security/PrivilegedActionException'> (0x00000007973ccbd0) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 7.044 Thread 0x00007fc882808000 Exception <a 'java/security/PrivilegedActionException'> (0x0000000796821488) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 7.048 Thread 0x00007fc882808000 Exception <a 'java/security/PrivilegedActionException'> (0x0000000796829358) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 7.918 Thread 0x00007fc882808000 Exception <a 'java/security/PrivilegedActionException'> (0x0000000796831d08) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 7.919 Thread 0x00007fc882808000 Exception <a 'java/security/PrivilegedActionException'> (0x00000007968388c0) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 7.919 Thread 0x00007fc882808000 Exception <a 'java/security/PrivilegedActionException'> (0x0000000796843a00) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 7.920 Thread 0x00007fc882808000 Exception <a 'java/security/PrivilegedActionException'> (0x0000000796849008) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 11.267 Thread 0x00007fc882808000 Exception <a 'java/security/PrivilegedActionException'> (0x000000079ca48fb0) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 26.541 Thread 0x00007fc882808000 Exception <a 'java/security/PrivilegedActionException'> (0x00000007a748bdb8) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+
+Events (10 events):
+Event: 22.987 Executing VM operation: RevokeBias done
+Event: 22.987 Thread 0x00007fc883136800 Thread exited: 0x00007fc883136800
+Event: 23.278 Thread 0x00007fc883c79800 Thread added: 0x00007fc883c79800
+Event: 23.319 Thread 0x00007fc883022000 flushing nmethod 0x000000010c261ad0
+Event: 23.319 Thread 0x00007fc883022000 flushing nmethod 0x000000010c264410
+Event: 23.319 Thread 0x00007fc883022000 flushing nmethod 0x000000010c26add0
+Event: 23.387 Thread 0x00007fc883054800 flushing nmethod 0x000000010c27ecd0
+Event: 23.387 Thread 0x00007fc883054800 flushing nmethod 0x000000010c28e9d0
+Event: 26.541 loading class org/lwjgl/opengl/CallbackUtil
+Event: 26.541 loading class org/lwjgl/opengl/CallbackUtil done
+
+
+Dynamic libraries:
+0x000000000d140000 	/System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa
+0x000000000d140000 	/System/Library/Frameworks/Security.framework/Versions/A/Security
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices
+0x000000000d140000 	/usr/lib/libz.1.dylib
+0x000000000d140000 	/usr/lib/libSystem.B.dylib
+0x000000000d140000 	/usr/lib/libobjc.A.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
+0x000000000d140000 	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation
+0x000000000d140000 	/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
+0x000000000d140000 	/System/Library/Frameworks/CoreData.framework/Versions/A/CoreData
+0x000000000d140000 	/System/Library/PrivateFrameworks/RemoteViewServices.framework/Versions/A/RemoteViewServices
+0x000000000d140000 	/System/Library/PrivateFrameworks/UIFoundation.framework/Versions/A/UIFoundation
+0x000000000d140000 	/System/Library/Frameworks/IOSurface.framework/Versions/A/IOSurface
+0x000000000d140000 	/System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox
+0x000000000d140000 	/System/Library/Frameworks/AudioUnit.framework/Versions/A/AudioUnit
+0x000000000d140000 	/System/Library/PrivateFrameworks/DataDetectorsCore.framework/Versions/A/DataDetectorsCore
+0x000000000d140000 	/System/Library/PrivateFrameworks/DesktopServicesPriv.framework/Versions/A/DesktopServicesPriv
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/HIToolbox
+0x000000000d140000 	/System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SpeechRecognition.framework/Versions/A/SpeechRecognition
+0x000000000d140000 	/usr/lib/libauto.dylib
+0x000000000d140000 	/usr/lib/libicucore.A.dylib
+0x000000000d140000 	/usr/lib/libxml2.2.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreUI.framework/Versions/A/CoreUI
+0x000000000d140000 	/System/Library/Frameworks/CoreAudio.framework/Versions/A/CoreAudio
+0x000000000d140000 	/System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration
+0x000000000d140000 	/usr/lib/liblangid.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/MultitouchSupport.framework/Versions/A/MultitouchSupport
+0x000000000d140000 	/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
+0x000000000d140000 	/usr/lib/libDiagnosticMessagesClient.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
+0x000000000d140000 	/System/Library/PrivateFrameworks/PerformanceAnalysis.framework/Versions/A/PerformanceAnalysis
+0x000000000d140000 	/System/Library/PrivateFrameworks/GenerationalStorage.framework/Versions/A/GenerationalStorage
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL
+0x000000000d140000 	/System/Library/PrivateFrameworks/Sharing.framework/Versions/A/Sharing
+0x000000000d140000 	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics
+0x000000000d140000 	/System/Library/Frameworks/CoreText.framework/Versions/A/CoreText
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO
+0x000000000d140000 	/usr/lib/libextension.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/Backup.framework/Versions/A/Backup
+0x000000000d140000 	/usr/lib/libarchive.2.dylib
+0x000000000d140000 	/System/Library/Frameworks/CFNetwork.framework/Versions/A/CFNetwork
+0x000000000d140000 	/System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration
+0x000000000d140000 	/usr/lib/libCRFSuite.dylib
+0x000000000d140000 	/usr/lib/libc++.1.dylib
+0x000000000d140000 	/usr/lib/libc++abi.dylib
+0x000000000d140000 	/usr/lib/system/libcache.dylib
+0x000000000d140000 	/usr/lib/system/libcommonCrypto.dylib
+0x000000000d140000 	/usr/lib/system/libcompiler_rt.dylib
+0x000000000d140000 	/usr/lib/system/libcopyfile.dylib
+0x000000000d140000 	/usr/lib/system/libcorecrypto.dylib
+0x000000000d140000 	/usr/lib/system/libdispatch.dylib
+0x000000000d140000 	/usr/lib/system/libdyld.dylib
+0x000000000d140000 	/usr/lib/system/libkeymgr.dylib
+0x000000000d140000 	/usr/lib/system/liblaunch.dylib
+0x000000000d140000 	/usr/lib/system/libmacho.dylib
+0x000000000d140000 	/usr/lib/system/libquarantine.dylib
+0x000000000d140000 	/usr/lib/system/libremovefile.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_asl.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_blocks.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_c.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_configuration.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_coreservices.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_coretls.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_dnssd.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_info.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_kernel.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_m.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_malloc.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_network.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_networkextension.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_notify.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_platform.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_pthread.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_sandbox.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_secinit.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_stats.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_trace.dylib
+0x000000000d140000 	/usr/lib/system/libunc.dylib
+0x000000000d140000 	/usr/lib/system/libunwind.dylib
+0x000000000d140000 	/usr/lib/system/libxpc.dylib
+0x000000000d140000 	/usr/lib/libbz2.1.0.dylib
+0x000000000d140000 	/usr/lib/liblzma.5.dylib
+0x000000000d140000 	/usr/lib/libbsm.0.dylib
+0x000000000d140000 	/usr/lib/libsqlite3.dylib
+0x000000000d140000 	/usr/lib/system/libkxld.dylib
+0x000000000d140000 	/usr/lib/libxar.1.dylib
+0x000000000d140000 	/usr/lib/libpam.2.dylib
+0x000000000d140000 	/usr/lib/libOpenScriptingUtil.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/FSEvents.framework/Versions/A/FSEvents
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/CarbonCore.framework/Versions/A/CarbonCore
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/Metadata.framework/Versions/A/Metadata
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/OSServices.framework/Versions/A/OSServices
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SearchKit.framework/Versions/A/SearchKit
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/AE.framework/Versions/A/AE
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/LaunchServices
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/DictionaryServices.framework/Versions/A/DictionaryServices
+0x000000000d140000 	/System/Library/Frameworks/NetFS.framework/Versions/A/NetFS
+0x000000000d140000 	/System/Library/PrivateFrameworks/NetAuth.framework/Versions/A/NetAuth
+0x000000000d140000 	/System/Library/PrivateFrameworks/login.framework/Versions/A/Frameworks/loginsupport.framework/Versions/A/loginsupport
+0x000000000d140000 	/System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC
+0x000000000d140000 	/usr/lib/libmecabra.dylib
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/ATS
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ColorSync.framework/Versions/A/ColorSync
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/HIServices.framework/Versions/A/HIServices
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/LangAnalysis.framework/Versions/A/LangAnalysis
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/PrintCore.framework/Versions/A/PrintCore
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/QD.framework/Versions/A/QD
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/SpeechSynthesis.framework/Versions/A/SpeechSynthesis
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Accelerate
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vImage.framework/Versions/A/vImage
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/vecLib
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvDSP.dylib
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvMisc.dylib
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLAPACK.dylib
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLinearAlgebra.dylib
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libFontParser.dylib
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libFontRegistry.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/AppleVPA.framework/Versions/A/AppleVPA
+0x000000000d140000 	/System/Library/PrivateFrameworks/AppleJPEG.framework/Versions/A/AppleJPEG
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJPEG.dylib
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libTIFF.dylib
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libPng.dylib
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libGIF.dylib
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJP2.dylib
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libRadiance.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreVideo.framework/Versions/A/CoreVideo
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLU.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGFXShared.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLImage.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCVMSPluginSupport.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCoreVMClient.dylib
+0x000000000d140000 	/usr/lib/libcups.2.dylib
+0x000000000d140000 	/System/Library/Frameworks/Kerberos.framework/Versions/A/Kerberos
+0x000000000d140000 	/System/Library/Frameworks/GSS.framework/Versions/A/GSS
+0x000000000d140000 	/usr/lib/libresolv.9.dylib
+0x000000000d140000 	/usr/lib/libiconv.2.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/Heimdal.framework/Versions/A/Heimdal
+0x000000000d140000 	/usr/lib/libheimdal-asn1.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenDirectory.framework/Versions/A/OpenDirectory
+0x000000000d140000 	/System/Library/PrivateFrameworks/CommonAuth.framework/Versions/A/CommonAuth
+0x000000000d140000 	/System/Library/Frameworks/OpenDirectory.framework/Versions/A/Frameworks/CFOpenDirectory.framework/Versions/A/CFOpenDirectory
+0x000000000d140000 	/System/Library/Frameworks/SecurityFoundation.framework/Versions/A/SecurityFoundation
+0x000000000d140000 	/System/Library/PrivateFrameworks/LanguageModeling.framework/Versions/A/LanguageModeling
+0x000000000d140000 	/usr/lib/libcmph.dylib
+0x000000000d140000 	/System/Library/Frameworks/ServiceManagement.framework/Versions/A/ServiceManagement
+0x000000000d140000 	/usr/lib/libxslt.1.dylib
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Ink.framework/Versions/A/Ink
+0x000000000d140000 	/System/Library/Frameworks/QuartzCore.framework/Versions/A/Frameworks/CoreImage.framework/Versions/A/CoreImage
+0x000000000d140000 	/System/Library/PrivateFrameworks/CrashReporterSupport.framework/Versions/A/CrashReporterSupport
+0x000000000d140000 	/System/Library/Frameworks/OpenCL.framework/Versions/A/OpenCL
+0x000000000d140000 	/System/Library/PrivateFrameworks/FaceCore.framework/Versions/A/FaceCore
+0x000000000d140000 	/System/Library/PrivateFrameworks/Ubiquity.framework/Versions/A/Ubiquity
+0x000000000d140000 	/System/Library/PrivateFrameworks/IconServices.framework/Versions/A/IconServices
+0x000000000d140000 	/System/Library/PrivateFrameworks/ChunkingLibrary.framework/Versions/A/ChunkingLibrary
+0x000000000d140000 	/System/Library/PrivateFrameworks/Apple80211.framework/Versions/A/Apple80211
+0x000000000d140000 	/System/Library/Frameworks/CoreWLAN.framework/Versions/A/CoreWLAN
+0x000000000d140000 	/System/Library/Frameworks/IOBluetooth.framework/Versions/A/IOBluetooth
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreWiFi.framework/Versions/A/CoreWiFi
+0x000000000d140000 	/System/Library/Frameworks/CoreBluetooth.framework/Versions/A/CoreBluetooth
+0x000000000d140000 	/System/Library/PrivateFrameworks/DebugSymbols.framework/Versions/A/DebugSymbols
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/CoreSymbolication
+0x000000000d140000 	/System/Library/PrivateFrameworks/Symbolication.framework/Versions/A/Symbolication
+0x000000000d140000 	/System/Library/PrivateFrameworks/SpeechRecognitionCore.framework/Versions/A/SpeechRecognitionCore
+0x000000010a8b4000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/server/libjvm.dylib
+0x000000000d140000 	/usr/lib/libstdc++.6.dylib
+0x000000010b7ea000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libverify.dylib
+0x000000010c103000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libjava.dylib
+0x000000010c13f000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libzip.dylib
+0x00000001221bd000 	/System/Library/Frameworks/JavaVM.framework/Frameworks/JavaRuntimeSupport.framework/JavaRuntimeSupport
+0x00000001221d3000 	/System/Library/Frameworks/JavaVM.framework/Versions/A/Frameworks/JavaNativeFoundation.framework/Versions/A/JavaNativeFoundation
+0x00000001221e7000 	/System/Library/Frameworks/JavaVM.framework/Versions/A/JavaVM
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Carbon
+0x00000001221f3000 	/System/Library/PrivateFrameworks/JavaLaunching.framework/Versions/A/JavaLaunching
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/CommonPanels.framework/Versions/A/CommonPanels
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Help.framework/Versions/A/Help
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/ImageCapture.framework/Versions/A/ImageCapture
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/OpenScripting.framework/Versions/A/OpenScripting
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Print.framework/Versions/A/Print
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SecurityHI.framework/Versions/A/SecurityHI
+0x000000012407d000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libawt.dylib
+0x000000012412c000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/./libmlib_image.dylib
+0x00000001241f8000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libawt_lwawt.dylib
+0x00000001242ab000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/./libosxapp.dylib
+0x000000000d140000 	/System/Library/Frameworks/ExceptionHandling.framework/Versions/A/ExceptionHandling
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreServicesInternal.framework/Versions/A/CoreServicesInternal
+0x000000000d140000 	/System/Library/PrivateFrameworks/CloudDocs.framework/Versions/A/CloudDocs
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreDuet.framework/Versions/A/CoreDuet
+0x000000000d140000 	/System/Library/Frameworks/CloudKit.framework/Versions/A/CloudKit
+0x000000000d140000 	/System/Library/PrivateFrameworks/ProtocolBuffer.framework/Versions/A/ProtocolBuffer
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreDuetDaemonProtocol.framework/Versions/A/CoreDuetDaemonProtocol
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreDuetDebugLogging.framework/Versions/A/CoreDuetDebugLogging
+0x000000000d140000 	/System/Library/Frameworks/CoreLocation.framework/Versions/A/CoreLocation
+0x000000000d140000 	/System/Library/Frameworks/Accounts.framework/Versions/A/Accounts
+0x000000000d140000 	/System/Library/PrivateFrameworks/ApplePushService.framework/Versions/A/ApplePushService
+0x000000000d140000 	/System/Library/PrivateFrameworks/GeoServices.framework/Versions/A/GeoServices
+0x000000000d140000 	/System/Library/PrivateFrameworks/OAuth.framework/Versions/A/OAuth
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreDaemon.framework/Versions/B/CoreDaemon
+0x000000000d140000 	/usr/lib/libcrypto.0.9.8.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/AppleSRP.framework/Versions/A/AppleSRP
+0x000000000d140000 	/System/Library/PrivateFrameworks/TrustEvaluationAgent.framework/Versions/A/TrustEvaluationAgent
+0x000000000d140000 	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Resources/libCGCMS.A.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Resources/libRIP.A.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/FamilyControls.framework/Versions/A/FamilyControls
+0x000000000d140000 	/System/Library/PrivateFrameworks/CommerceKit.framework/Versions/A/Frameworks/CommerceCore.framework/Versions/A/CommerceCore
+0x000000000d140000 	/System/Library/PrivateFrameworks/SystemAdministration.framework/Versions/A/SystemAdministration
+0x000000000d140000 	/System/Library/PrivateFrameworks/AppContainer.framework/Versions/A/AppContainer
+0x000000000d140000 	/System/Library/PrivateFrameworks/SecCodeWrapper.framework/Versions/A/SecCodeWrapper
+0x000000000d140000 	/System/Library/Frameworks/DirectoryService.framework/Versions/A/DirectoryService
+0x000000000d140000 	/System/Library/PrivateFrameworks/DiskImages.framework/Versions/A/DiskImages
+0x000000000d140000 	/System/Library/PrivateFrameworks/LoginUIKit.framework/Versions/A/Frameworks/LoginUICore.framework/Versions/A/LoginUICore
+0x000000000d140000 	/usr/lib/libCoreStorage.dylib
+0x000000000d140000 	/usr/lib/libcsfde.dylib
+0x000000000d140000 	/usr/lib/libodfde.dylib
+0x000000000d140000 	/System/Library/Frameworks/DiscRecording.framework/Versions/A/DiscRecording
+0x000000000d140000 	/usr/lib/libcurl.4.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/MediaKit.framework/Versions/A/MediaKit
+0x000000000d140000 	/System/Library/PrivateFrameworks/ProtectedCloudStorage.framework/Versions/A/ProtectedCloudStorage
+0x000000000d140000 	/System/Library/PrivateFrameworks/EFILogin.framework/Versions/A/EFILogin
+0x000000000d140000 	/usr/lib/libutil.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/FindMyDevice.framework/Versions/A/FindMyDevice
+0x000000000d140000 	/System/Library/Frameworks/LDAP.framework/Versions/A/LDAP
+0x000000000d140000 	/usr/lib/libsasl2.2.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Resources/libCGXType.A.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenCL.framework/Versions/A/Libraries/libcldcpuengine.dylib
+0x0000000126320000 	cl_kernels
+0x0000000127da0000 	/System/Library/Frameworks/OpenCL.framework/Versions/A/Libraries/ImageFormats/unorm8_bgra.dylib
+0x0000000126311000 	cl_kernels
+0x000000012806d000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libfontmanager.dylib
+0x00000001280d4000 	/Users/ShantalOlono/Life/slick/liblwjgl.dylib
+0x0000000126317000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libjawt.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Resources/GLEngine.bundle/GLEngine
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLProgrammability.dylib
+0x0000000000000000 	/System/Library/Extensions/AppleIntelHD4000GraphicsGLDriver.bundle/Contents/MacOS/AppleIntelHD4000GraphicsGLDriver
+0x000000000d140000 	/System/Library/PrivateFrameworks/IOAccelerator.framework/Versions/A/IOAccelerator
+0x000000000d140000 	/System/Library/PrivateFrameworks/GPUSupport.framework/Versions/A/Libraries/libGPUSupportMercury.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Resources/GLRendererFloat.bundle/GLRendererFloat
+0x0000000128988000 	/Users/ShantalOlono/Life/slick/libjinput-osx.dylib
+0x000000012898d000 	/System/Library/Extensions/IOHIDFamily.kext/Contents/PlugIns/IOHIDLib.plugin/Contents/MacOS/IOHIDLib
+0x0000000136b27000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libnet.dylib
+0x0000000136a6d000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libnio.dylib
+
+VM Arguments:
+jvm_args: -Djava.library.path=/Users/ShantalOlono/Life/slick -Dfile.encoding=UTF-8 
+java_command: main.java.edu.asu.cst316.Game
+java_class_path (initial): /Users/ShantalOlono/Life/bin:/Users/ShantalOlono/Life/jar/jacocoagent.jar:/Users/ShantalOlono/Life/jar/jacocoant.jar:/Users/ShantalOlono/Life/jar/junit.jar:/Users/ShantalOlono/Life/jar/org.jacoco.agent-0.7.4.201502262128.jar:/Users/ShantalOlono/Life/jar/org.jacoco.ant-0.7.4.201502262128.jar:/Users/ShantalOlono/Life/jar/org.jacoco.core-0.7.4.201502262128.jar:/Users/ShantalOlono/Life/jar/org.jacoco.report-0.7.4.201502262128.jar:/Users/ShantalOlono/Life/slick/lib/commons-math3-3.3.jar:/Users/ShantalOlono/Life/slick/lib/ibxm.jar:/Users/ShantalOlono/Life/slick/lib/jinput.jar:/Users/ShantalOlono/Life/slick/lib/jnlp.jar:/Users/ShantalOlono/Life/slick/lib/jogg-0.0.7.jar:/Users/ShantalOlono/Life/slick/lib/jorbis-0.0.15.jar:/Users/ShantalOlono/Life/slick/lib/lwjgl_util_applet.jar:/Users/ShantalOlono/Life/slick/lib/lwjgl_util.jar:/Users/ShantalOlono/Life/slick/lib/lwjgl.jar:/Users/ShantalOlono/Life/slick/lib/natives-linux.jar:/Users/ShantalOlono/Life/slick/lib/natives-mac.jar:/Users/ShantalOlono/Life/slick/lib/natives-windows.jar:/Users/ShantalOlono/Life/slick/lib/Pack200Task.jar:/Users/ShantalOlono/Life/slick/lib/slick-examples.jar:/Users/ShantalOlono/Life/slick/lib/slick.jar:/Users/ShantalOlono/Life/slick/lib/tinylinepp.jar
+Launcher Type: SUN_STANDARD
+
+Environment Variables:
+PATH=/usr/bin:/bin:/usr/sbin:/sbin
+SHELL=/bin/bash
+
+Signal Handlers:
+SIGSEGV: [libjvm.dylib+0x57a0e7], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_ONSTACK|SA_RESTART|SA_SIGINFO
+SIGBUS: [libjvm.dylib+0x57a0e7], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGFPE: [libjvm.dylib+0x45af24], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGPIPE: [libjvm.dylib+0x45af24], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGXFSZ: [libjvm.dylib+0x45af24], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGILL: [libjvm.dylib+0x45af24], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGUSR1: SIG_DFL, sa_mask[0]=00000000000000000000000000000000, sa_flags=none
+SIGUSR2: [libjvm.dylib+0x45aa42], sa_mask[0]=00100000000000000000000000000000, sa_flags=SA_RESTART|SA_SIGINFO
+SIGHUP: [libjvm.dylib+0x459015], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGINT: [libjvm.dylib+0x459015], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGTERM: [libjvm.dylib+0x459015], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGQUIT: [libjvm.dylib+0x459015], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+
+
+---------------  S Y S T E M  ---------------
+
+OS:Bsduname:Darwin 14.1.0 Darwin Kernel Version 14.1.0: Mon Dec 22 23:10:38 PST 2014; root:xnu-2782.10.72~2/RELEASE_X86_64 x86_64
+rlimit: STACK 8192k, CORE 0k, NPROC 709, NOFILE 10240, AS infinity
+load average:2.63 2.39 2.15
+
+CPU:total 4 (2 cores per cpu, 2 threads per core) family 6 model 58 stepping 9, cmov, cx8, fxsr, mmx, sse, sse2, sse3, ssse3, sse4.1, sse4.2, popcnt, avx, aes, clmul, erms, ht, tsc, tscinvbit, tscinv
+
+Memory: 4k page, physical 8388608k(760016k free)
+
+/proc/meminfo:
+
+
+vm_info: Java HotSpot(TM) 64-Bit Server VM (25.31-b07) for bsd-amd64 JRE (1.8.0_31-b13), built on Dec 17 2014 20:45:36 by "java_re" with gcc 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2336.11.00)
+
+time: Mon Apr 20 18:10:20 2015
+elapsed time: 26 seconds (0d 0h 0m 26s)
+

--- a/hs_err_pid9083.log
+++ b/hs_err_pid9083.log
@@ -1,0 +1,620 @@
+#
+# A fatal error has been detected by the Java Runtime Environment:
+#
+#  SIGSEGV (0xb) at pc=0x00007fff97b560dd, pid=9083, tid=1811
+#
+# JRE version: Java(TM) SE Runtime Environment (8.0_31-b13) (build 1.8.0_31-b13)
+# Java VM: Java HotSpot(TM) 64-Bit Server VM (25.31-b07 mixed mode bsd-amd64 compressed oops)
+# Problematic frame:
+# C  [libobjc.A.dylib+0x10dd]  objc_msgSend+0x1d
+#
+# Failed to write core dump. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
+#
+# If you would like to submit a bug report, please visit:
+#   http://bugreport.java.com/bugreport/crash.jsp
+# The crash happened outside the Java Virtual Machine in native code.
+# See problematic frame for where to report the bug.
+#
+
+---------------  T H R E A D  ---------------
+
+Current thread (0x00007fd4340d6800):  JavaThread "AppKit Thread" daemon [_thread_in_native, id=1811, stack(0x00007fff52ebd000,0x00007fff536bd000)]
+
+siginfo: si_signo: 11 (SIGSEGV), si_code: 1 (SEGV_MAPERR), si_addr: 0x000007fd43365d40
+
+Registers:
+RAX=0x00007fd433649010, RBX=0x00007fff536b8448, RCX=0x0000000000000000, RDX=0x00007fd435e0b0a0
+RSP=0x00007fff536b8268, RBP=0x00007fff536b8270, RSI=0x00007fff901e02b4, RDI=0x00007fd433649010
+R8 =0x00007fff536b8250, R9 =0x0000000000000063, R10=0x00007fff901e02b4, R11=0x000007fd43365d28
+R12=0x00007fd4334031e0, R13=0x00000000000f4310, R14=0x00007fd433516250, R15=0x00007fff536b83a8
+RIP=0x00007fff97b560dd, EFLAGS=0x0000000000010206, ERR=0x0000000000000004
+  TRAPNO=0x000000000000000e
+
+Top of Stack: (sp=0x00007fff536b8268)
+0x00007fff536b8268:   00007fff90a8ecdc 00007fff536b85d0
+0x00007fff536b8278:   00007fff90980244 00007fff536b82fc
+0x00007fff536b8288:   00007fff536b8300 00007fff536b8304
+0x00007fff536b8298:   00007fff7e5a1c88 ffffffffffffffff
+0x00007fff536b82a8:   0000000000000948 00007fff7e5a1ca0
+0x00007fff536b82b8:   00007fd433516250 0000000000000000
+0x00007fff536b82c8:   00007fff536b83a0 0000000000000000
+0x00007fff536b82d8:   00007fd43376df40 00007fff536b8420
+0x00007fff536b82e8:   0000000000000063 00000000000f4312
+0x00007fff536b82f8:   00007fd435e0b0a0 00007fd43376d9f0
+0x00007fff536b8308:   00007fd4334031e0 0000000000000001
+0x00007fff536b8318:   00000000000f4310 00007fd4334031d0
+0x00007fff536b8328:   00007fff946047ba 00000001351a1380
+0x00007fff536b8338:   00007fff7f6e20d0 0000000042000000
+0x00007fff536b8348:   00007fff9460ce13 00007fff7e56c1d0
+0x00007fff536b8358:   00007fff536b8428 0000000000000000
+0x00007fff536b8368:   00007fff7eb4a8c8 0000000000000000
+0x00007fff536b8378:   000000000000000a 0004370300000001
+0x00007fff536b8388:   00007fd433403204 0000000000000000
+0x00007fff536b8398:   000000000053b601 00007fd43376dfc0
+0x00007fff536b83a8:   00007fd433516250 0000000000000000
+0x00007fff536b83b8:   00007fff9021834c 00007fff536b8460
+0x00007fff536b83c8:   00007fff9b943513 00007fff536b8444
+0x00007fff536b83d8:   000000000053b701 00000000ffffffff
+0x00007fff536b83e8:   00007fff7eb4a8c8 000000000053b700
+0x00007fff536b83f8:   00007fff00000000 00007fff536b84f0
+0x00007fff536b8408:   00007fff9ae8fedc 00007fff7eb4a8e8
+0x00007fff536b8418:   00007fff9021834c 0000000000000051
+0x00007fff536b8428:   0000000000000000 00000000000f42e2
+0x00007fff536b8438:   0000000000000054 0000000000000000
+0x00007fff536b8448:   00000000000f4310 00007fff536b84c4
+0x00007fff536b8458:   000000000053be01 00000000ffffffff 
+
+Instructions: (pc=0x00007fff97b560dd)
+0x00007fff97b560bd:   00 00 00 48 85 ff 2e 74 7a 40 f6 c7 01 2e 75 7e
+0x00007fff97b560cd:   49 bb f8 ff ff ff ff 7f 00 00 4c 23 1f 49 89 f2
+0x00007fff97b560dd:   45 23 53 18 49 c1 e2 04 4d 03 53 10 49 3b 32 75
+0x00007fff97b560ed:   04 41 ff 62 08 49 83 3a 00 74 6a 4d 3b 53 10 74 
+
+Register to memory mapping:
+
+RAX=0x00007fd433649010 is an unknown value
+RBX=0x00007fff536b8448 is pointing into the stack for thread: 0x00007fd4340d6800
+RCX=0x0000000000000000 is an unknown value
+RDX=0x00007fd435e0b0a0 is an unknown value
+RSP=0x00007fff536b8268 is pointing into the stack for thread: 0x00007fd4340d6800
+RBP=0x00007fff536b8270 is pointing into the stack for thread: 0x00007fd4340d6800
+RSI=0x00007fff901e02b4: -[NSTitlebarContainerView shouldRoundCorners]+0x5ced6 in /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit at 0x00007fff8f80f000
+RDI=0x00007fd433649010 is an unknown value
+R8 =0x00007fff536b8250 is pointing into the stack for thread: 0x00007fd4340d6800
+R9 =0x0000000000000063 is an unknown value
+R10=0x00007fff901e02b4: -[NSTitlebarContainerView shouldRoundCorners]+0x5ced6 in /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit at 0x00007fff8f80f000
+R11=0x000007fd43365d28 is an unknown value
+R12=0x00007fd4334031e0 is an unknown value
+R13=0x00000000000f4310 is an unknown value
+R14=0x00007fd433516250 is an unknown value
+R15=0x00007fff536b83a8 is pointing into the stack for thread: 0x00007fd4340d6800
+
+
+Stack: [0x00007fff52ebd000,0x00007fff536bd000],  sp=0x00007fff536b8268,  free space=8172k
+Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
+C  [libobjc.A.dylib+0x10dd]  objc_msgSend+0x1d
+C  [CoreFoundation+0x10244]  _CFXNotificationPost+0xc44
+C  [Foundation+0x2c31]  -[NSNotificationCenter postNotificationName:object:userInfo:]+0x42
+C  [AppKit+0xdd776]  -[NSSurface _disposeSurface]+0x98
+C  [AppKit+0xdd1da]  -[NSSurface setWindow:]+0x42
+C  [AppKit+0x3b9ef]  -[NSView _setWindow:]+0xa22
+C  [AppKit+0x3cc22]  -[NSView removeFromSuperview]+0x1c5
+C  [AppKit+0x9140a]  -[NSView removeFromSuperviewWithoutNeedingDisplay]+0x26
+C  [liblwjgl.dylib+0xa205]  +[MacOSXKeyableWindow destroyWindow]+0xb5
+C  [Foundation+0x65cdc]  __NSThreadPerformPerform+0x125
+C  [CoreFoundation+0x80681]  __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__+0x11
+C  [CoreFoundation+0x7280d]  __CFRunLoopDoSources0+0x10d
+C  [CoreFoundation+0x71e3f]  __CFRunLoopRun+0x39f
+C  [CoreFoundation+0x71858]  CFRunLoopRunSpecific+0x128
+C  [HIToolbox+0x2eaef]  RunCurrentEventLoopInMode+0xeb
+C  [HIToolbox+0x2e86a]  ReceiveNextEventCommon+0x1af
+C  [HIToolbox+0x2e6ab]  _BlockUntilNextEventMatchingListInModeWithFilter+0x47
+C  [AppKit+0x23f81]  _DPSNextEvent+0x3c4
+C  [AppKit+0x23730]  -[NSApplication nextEventMatchingMask:untilDate:inMode:dequeue:]+0xc2
+C  [libosxapp.dylib+0x242a]  -[NSApplicationAWT nextEventMatchingMask:untilDate:inMode:dequeue:]+0x7c
+C  [AppKit+0x17593]  -[NSApplication run]+0x252
+C  [libosxapp.dylib+0x223e]  +[NSApplicationAWT runAWTLoopWithApp:]+0x9c
+C  [libawt_lwawt.dylib+0x4494f]  -[AWTStarter starter:]+0x389
+C  [Foundation+0x65cdc]  __NSThreadPerformPerform+0x125
+C  [CoreFoundation+0x80681]  __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__+0x11
+C  [CoreFoundation+0x7280d]  __CFRunLoopDoSources0+0x10d
+C  [CoreFoundation+0x71e3f]  __CFRunLoopRun+0x39f
+C  [CoreFoundation+0x71858]  CFRunLoopRunSpecific+0x128
+C  [java+0x56cc]  CreateExecutionEnvironment+0x367
+C  [java+0x165c]  JLI_Launch+0x7a0
+C  [java+0x768a]  main+0x65
+C  [java+0xeb4]  start+0x34
+C  0x0000000000000006
+
+
+---------------  P R O C E S S  ---------------
+
+Java Threads: ( => current thread )
+  0x00007fd435195000 JavaThread "Java2D Disposer" daemon [_thread_blocked, id=60679, stack(0x00000001385df000,0x00000001386df000)]
+  0x00007fd434a35800 JavaThread "Java2D Queue Flusher" daemon [_thread_blocked, id=60423, stack(0x0000000137c43000,0x0000000137d43000)]
+  0x00007fd435078800 JavaThread "AWT-Shutdown" [_thread_blocked, id=28679, stack(0x00000001273b4000,0x00000001274b4000)]
+=>0x00007fd4340d6800 JavaThread "AppKit Thread" daemon [_thread_in_native, id=1811, stack(0x00007fff52ebd000,0x00007fff536bd000)]
+  0x00007fd435020000 JavaThread "Service Thread" daemon [_thread_blocked, id=18179, stack(0x0000000125b94000,0x0000000125c94000)]
+  0x00007fd435015800 JavaThread "C1 CompilerThread2" daemon [_thread_blocked, id=17667, stack(0x0000000125a91000,0x0000000125b91000)]
+  0x00007fd435014800 JavaThread "C2 CompilerThread1" daemon [_thread_blocked, id=17155, stack(0x000000012598e000,0x0000000125a8e000)]
+  0x00007fd43480a800 JavaThread "C2 CompilerThread0" daemon [_thread_blocked, id=16643, stack(0x000000012588b000,0x000000012598b000)]
+  0x00007fd435013000 JavaThread "Signal Dispatcher" daemon [_thread_blocked, id=13583, stack(0x0000000125788000,0x0000000125888000)]
+  0x00007fd434008000 JavaThread "Finalizer" daemon [_thread_blocked, id=11523, stack(0x0000000123e4e000,0x0000000123f4e000)]
+  0x00007fd434809000 JavaThread "Reference Handler" daemon [_thread_blocked, id=11011, stack(0x0000000123d4b000,0x0000000123e4b000)]
+  0x00007fd43400a000 JavaThread "main" [_thread_in_native, id=4867, stack(0x000000010de01000,0x000000010df01000)]
+
+Other Threads:
+  0x00007fd434806000 VMThread [stack: 0x0000000123c48000,0x0000000123d48000] [id=10499]
+  0x00007fd434070800 WatcherThread [stack: 0x0000000125c97000,0x0000000125d97000] [id=18691]
+
+VM state:not at safepoint (normal execution)
+
+VM Mutex/Monitor currently owned by a thread: None
+
+Heap:
+ PSYoungGen      total 222208K, used 215820K [0x0000000795580000, 0x00000007ab380000, 0x00000007c0000000)
+  eden space 212480K, 98% used [0x0000000795580000,0x00000007a2287170,0x00000007a2500000)
+  from space 9728K, 60% used [0x00000007a2500000,0x00000007a2abc060,0x00000007a2e80000)
+  to   space 9216K, 0% used [0x00000007aaa80000,0x00000007aaa80000,0x00000007ab380000)
+ ParOldGen       total 87552K, used 10465K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 11% used [0x0000000740000000,0x0000000740a38450,0x0000000745580000)
+ Metaspace       used 10240K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1067K, capacity 1117K, committed 1152K, reserved 1048576K
+
+Card table byte_map: [0x000000011d2c3000,0x000000011d6c4000] byte_map_base: 0x00000001198c3000
+
+Marking Bits: (ParMarkBitMap*) 0x000000010cedf410
+ Begin Bits: [0x000000011dd7b000, 0x000000011fd7b000)
+ End Bits:   [0x000000011fd7b000, 0x0000000121d7b000)
+
+Polling page: 0x000000010d5b9000
+
+CodeCache: size=245760Kb used=4548Kb max_used=4558Kb free=241211Kb
+ bounds [0x000000010df03000, 0x000000010e383000, 0x000000011cf03000]
+ total_blobs=1761 nmethods=1233 adapters=443
+ compilation: enabled
+
+Compilation events (10 events):
+Event: 16.194 Thread 0x00007fd435014800 1230       4       sun.net.www.ParseUtil::encodePath (336 bytes)
+Event: 16.221 Thread 0x00007fd435014800 nmethod 1230 0x000000010e378010 code [0x000000010e378260, 0x000000010e3792a8]
+Event: 16.365 Thread 0x00007fd435015800 1231       3       java.lang.Integer::toString (48 bytes)
+Event: 16.366 Thread 0x00007fd435015800 nmethod 1231 0x000000010e377450 code [0x000000010e377620, 0x000000010e377c68]
+Event: 16.366 Thread 0x00007fd435015800 1232       3       org.newdawn.slick.opengl.TextureImpl::getWidth (5 bytes)
+Event: 16.367 Thread 0x00007fd435015800 nmethod 1232 0x000000010e377110 code [0x000000010e377260, 0x000000010e3773b0]
+Event: 16.367 Thread 0x00007fd435015800 1233       3       org.newdawn.slick.opengl.TextureImpl::getHeight (5 bytes)
+Event: 16.367 Thread 0x00007fd435015800 nmethod 1233 0x000000010e376dd0 code [0x000000010e376f20, 0x000000010e377070]
+Event: 16.391 Thread 0x00007fd435015800 1234       3       org.newdawn.slick.Image::initImpl (1 bytes)
+Event: 16.391 Thread 0x00007fd435015800 nmethod 1234 0x000000010e376a90 code [0x000000010e376be0, 0x000000010e376d30]
+
+GC Heap History (10 events):
+Event: 10.112 GC heap before
+{Heap before GC invocations=7 (full 0):
+ PSYoungGen      total 75776K, used 73840K [0x0000000795580000, 0x000000079a880000, 0x00000007c0000000)
+  eden space 66560K, 100% used [0x0000000795580000,0x0000000799680000,0x0000000799680000)
+  from space 9216K, 78% used [0x0000000799f80000,0x000000079a69c060,0x000000079a880000)
+  to   space 9216K, 0% used [0x0000000799680000,0x0000000799680000,0x0000000799f80000)
+ ParOldGen       total 87552K, used 8372K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 9% used [0x0000000740000000,0x000000074082d300,0x0000000745580000)
+ Metaspace       used 10150K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1066K, capacity 1117K, committed 1152K, reserved 1048576K
+Event: 10.119 GC heap after
+Heap after GC invocations=7 (full 0):
+ PSYoungGen      total 75776K, used 5408K [0x0000000795580000, 0x000000079e980000, 0x00000007c0000000)
+  eden space 66560K, 0% used [0x0000000795580000,0x0000000795580000,0x0000000799680000)
+  from space 9216K, 58% used [0x0000000799680000,0x0000000799bc8050,0x0000000799f80000)
+  to   space 9216K, 0% used [0x000000079e080000,0x000000079e080000,0x000000079e980000)
+ ParOldGen       total 87552K, used 10345K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 11% used [0x0000000740000000,0x0000000740a1a440,0x0000000745580000)
+ Metaspace       used 10150K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1066K, capacity 1117K, committed 1152K, reserved 1048576K
+}
+Event: 10.484 GC heap before
+{Heap before GC invocations=8 (full 0):
+ PSYoungGen      total 75776K, used 71043K [0x0000000795580000, 0x000000079e980000, 0x00000007c0000000)
+  eden space 66560K, 98% used [0x0000000795580000,0x0000000799598c28,0x0000000799680000)
+  from space 9216K, 58% used [0x0000000799680000,0x0000000799bc8050,0x0000000799f80000)
+  to   space 9216K, 0% used [0x000000079e080000,0x000000079e080000,0x000000079e980000)
+ ParOldGen       total 87552K, used 10345K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 11% used [0x0000000740000000,0x0000000740a1a440,0x0000000745580000)
+ Metaspace       used 10158K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1066K, capacity 1117K, committed 1152K, reserved 1048576K
+Event: 10.488 GC heap after
+Heap after GC invocations=8 (full 0):
+ PSYoungGen      total 141824K, used 1400K [0x0000000795580000, 0x000000079ea80000, 0x00000007c0000000)
+  eden space 132608K, 0% used [0x0000000795580000,0x0000000795580000,0x000000079d700000)
+  from space 9216K, 15% used [0x000000079e080000,0x000000079e1de020,0x000000079e980000)
+  to   space 9728K, 0% used [0x000000079d700000,0x000000079d700000,0x000000079e080000)
+ ParOldGen       total 87552K, used 10369K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 11% used [0x0000000740000000,0x0000000740a20440,0x0000000745580000)
+ Metaspace       used 10158K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1066K, capacity 1117K, committed 1152K, reserved 1048576K
+}
+Event: 11.306 GC heap before
+{Heap before GC invocations=9 (full 0):
+ PSYoungGen      total 141824K, used 134008K [0x0000000795580000, 0x000000079ea80000, 0x00000007c0000000)
+  eden space 132608K, 100% used [0x0000000795580000,0x000000079d700000,0x000000079d700000)
+  from space 9216K, 15% used [0x000000079e080000,0x000000079e1de020,0x000000079e980000)
+  to   space 9728K, 0% used [0x000000079d700000,0x000000079d700000,0x000000079e080000)
+ ParOldGen       total 87552K, used 10369K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 11% used [0x0000000740000000,0x0000000740a20440,0x0000000745580000)
+ Metaspace       used 10164K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1066K, capacity 1117K, committed 1152K, reserved 1048576K
+Event: 11.311 GC heap after
+Heap after GC invocations=9 (full 0):
+ PSYoungGen      total 142336K, used 6624K [0x0000000795580000, 0x00000007a3800000, 0x00000007c0000000)
+  eden space 132608K, 0% used [0x0000000795580000,0x0000000795580000,0x000000079d700000)
+  from space 9728K, 68% used [0x000000079d700000,0x000000079dd78060,0x000000079e080000)
+  to   space 9728K, 0% used [0x00000007a2e80000,0x00000007a2e80000,0x00000007a3800000)
+ ParOldGen       total 87552K, used 10393K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 11% used [0x0000000740000000,0x0000000740a26440,0x0000000745580000)
+ Metaspace       used 10164K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1066K, capacity 1117K, committed 1152K, reserved 1048576K
+}
+Event: 11.924 GC heap before
+{Heap before GC invocations=10 (full 0):
+ PSYoungGen      total 142336K, used 139232K [0x0000000795580000, 0x00000007a3800000, 0x00000007c0000000)
+  eden space 132608K, 100% used [0x0000000795580000,0x000000079d700000,0x000000079d700000)
+  from space 9728K, 68% used [0x000000079d700000,0x000000079dd78060,0x000000079e080000)
+  to   space 9728K, 0% used [0x00000007a2e80000,0x00000007a2e80000,0x00000007a3800000)
+ ParOldGen       total 87552K, used 10393K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 11% used [0x0000000740000000,0x0000000740a26440,0x0000000745580000)
+ Metaspace       used 10168K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1066K, capacity 1117K, committed 1152K, reserved 1048576K
+Event: 11.930 GC heap after
+Heap after GC invocations=10 (full 0):
+ PSYoungGen      total 222208K, used 6624K [0x0000000795580000, 0x00000007a3800000, 0x00000007c0000000)
+  eden space 212480K, 0% used [0x0000000795580000,0x0000000795580000,0x00000007a2500000)
+  from space 9728K, 68% used [0x00000007a2e80000,0x00000007a34f8060,0x00000007a3800000)
+  to   space 9728K, 0% used [0x00000007a2500000,0x00000007a2500000,0x00000007a2e80000)
+ ParOldGen       total 87552K, used 10441K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 11% used [0x0000000740000000,0x0000000740a32450,0x0000000745580000)
+ Metaspace       used 10168K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1066K, capacity 1117K, committed 1152K, reserved 1048576K
+}
+Event: 13.214 GC heap before
+{Heap before GC invocations=11 (full 0):
+ PSYoungGen      total 222208K, used 219104K [0x0000000795580000, 0x00000007a3800000, 0x00000007c0000000)
+  eden space 212480K, 100% used [0x0000000795580000,0x00000007a2500000,0x00000007a2500000)
+  from space 9728K, 68% used [0x00000007a2e80000,0x00000007a34f8060,0x00000007a3800000)
+  to   space 9728K, 0% used [0x00000007a2500000,0x00000007a2500000,0x00000007a2e80000)
+ ParOldGen       total 87552K, used 10441K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 11% used [0x0000000740000000,0x0000000740a32450,0x0000000745580000)
+ Metaspace       used 10181K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1066K, capacity 1117K, committed 1152K, reserved 1048576K
+Event: 13.224 GC heap after
+Heap after GC invocations=11 (full 0):
+ PSYoungGen      total 222208K, used 5872K [0x0000000795580000, 0x00000007ab380000, 0x00000007c0000000)
+  eden space 212480K, 0% used [0x0000000795580000,0x0000000795580000,0x00000007a2500000)
+  from space 9728K, 60% used [0x00000007a2500000,0x00000007a2abc060,0x00000007a2e80000)
+  to   space 9216K, 0% used [0x00000007aaa80000,0x00000007aaa80000,0x00000007ab380000)
+ ParOldGen       total 87552K, used 10465K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 11% used [0x0000000740000000,0x0000000740a38450,0x0000000745580000)
+ Metaspace       used 10181K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1066K, capacity 1117K, committed 1152K, reserved 1048576K
+}
+
+Deoptimization events (10 events):
+Event: 4.114 Thread 0x00007fd43400a000 Uncommon trap: reason=class_check action=maybe_recompile pc=0x000000010e134428 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 91
+Event: 4.114 Thread 0x00007fd43400a000 Uncommon trap: reason=class_check action=maybe_recompile pc=0x000000010e134428 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 91
+Event: 4.114 Thread 0x00007fd43400a000 Uncommon trap: reason=class_check action=maybe_recompile pc=0x000000010e134428 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 91
+Event: 4.114 Thread 0x00007fd43400a000 Uncommon trap: reason=class_check action=maybe_recompile pc=0x000000010e134428 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 91
+Event: 4.114 Thread 0x00007fd43400a000 Uncommon trap: reason=class_check action=maybe_recompile pc=0x000000010e12e284 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 91
+Event: 7.760 Thread 0x00007fd43400a000 Uncommon trap: reason=class_check action=maybe_recompile pc=0x000000010e221654 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 253
+Event: 7.761 Thread 0x00007fd43400a000 Uncommon trap: reason=class_check action=maybe_recompile pc=0x000000010e221654 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 253
+Event: 11.216 Thread 0x00007fd43400a000 Uncommon trap: reason=unloaded action=reinterpret pc=0x000000010e2e55b8 method=sun.font.CStrike$GlyphInfoCache.get(I)J @ 58
+Event: 11.223 Thread 0x00007fd43400a000 Uncommon trap: reason=range_check action=make_not_entrant pc=0x000000010e2e8884 method=java.awt.geom.AffineTransform.<init>([D)V @ 7
+Event: 12.738 Thread 0x00007fd43400a000 Uncommon trap: reason=range_check action=make_not_entrant pc=0x000000010e314274 method=sun.font.CCharToGlyphMapper$Cache.get(I[C[I)V @ 345
+
+Internal exceptions (10 events):
+Event: 7.666 Thread 0x00007fd43400a000 Exception <a 'java/security/PrivilegedActionException'> (0x0000000795cbf5a0) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 8.000 Thread 0x00007fd43400a000 Exception <a 'java/security/PrivilegedActionException'> (0x00000007973260a0) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 8.224 Thread 0x00007fd43400a000 Exception <a 'java/security/PrivilegedActionException'> (0x000000079682c6e0) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 8.232 Thread 0x00007fd43400a000 Exception <a 'java/security/PrivilegedActionException'> (0x00000007968345b0) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 9.025 Thread 0x00007fd43400a000 Exception <a 'java/security/PrivilegedActionException'> (0x000000079683c9d8) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 9.025 Thread 0x00007fd43400a000 Exception <a 'java/security/PrivilegedActionException'> (0x0000000796843590) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 9.026 Thread 0x00007fd43400a000 Exception <a 'java/security/PrivilegedActionException'> (0x000000079684e730) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 9.080 Thread 0x00007fd43400a000 Exception <a 'java/security/PrivilegedActionException'> (0x0000000796852820) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 12.611 Thread 0x00007fd43400a000 Exception <a 'java/security/PrivilegedActionException'> (0x000000079c769658) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 16.416 Thread 0x00007fd43400a000 Exception <a 'java/security/PrivilegedActionException'> (0x00000007a1fc77a0) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+
+Events (10 events):
+Event: 12.738 Executing VM operation: RevokeBias
+Event: 12.738 Executing VM operation: RevokeBias done
+Event: 12.738 Thread 0x00007fd43400a000 DEOPT PACKING pc=0x000000010e314274 sp=0x000000010df003b0
+Event: 12.739 Thread 0x00007fd43400a000 DEOPT UNPACKING pc=0x000000010df07f69 sp=0x000000010df00360 mode 2
+Event: 13.214 Executing VM operation: ParallelGCFailedAllocation
+Event: 13.225 Executing VM operation: ParallelGCFailedAllocation done
+Event: 13.458 Thread 0x00007fd43400a000 DEOPT PACKING pc=0x000000010e15570b sp=0x000000010df00030
+Event: 13.458 Thread 0x00007fd43400a000 DEOPT UNPACKING pc=0x000000010df4a373 sp=0x000000010deffe58 mode 0
+Event: 16.416 loading class org/lwjgl/opengl/CallbackUtil
+Event: 16.416 loading class org/lwjgl/opengl/CallbackUtil done
+
+
+Dynamic libraries:
+0x000000000d140000 	/System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa
+0x000000000d140000 	/System/Library/Frameworks/Security.framework/Versions/A/Security
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices
+0x000000000d140000 	/usr/lib/libz.1.dylib
+0x000000000d140000 	/usr/lib/libSystem.B.dylib
+0x000000000d140000 	/usr/lib/libobjc.A.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
+0x000000000d140000 	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation
+0x000000000d140000 	/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
+0x000000000d140000 	/System/Library/Frameworks/CoreData.framework/Versions/A/CoreData
+0x000000000d140000 	/System/Library/PrivateFrameworks/RemoteViewServices.framework/Versions/A/RemoteViewServices
+0x000000000d140000 	/System/Library/PrivateFrameworks/UIFoundation.framework/Versions/A/UIFoundation
+0x000000000d140000 	/System/Library/Frameworks/IOSurface.framework/Versions/A/IOSurface
+0x000000000d140000 	/System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox
+0x000000000d140000 	/System/Library/Frameworks/AudioUnit.framework/Versions/A/AudioUnit
+0x000000000d140000 	/System/Library/PrivateFrameworks/DataDetectorsCore.framework/Versions/A/DataDetectorsCore
+0x000000000d140000 	/System/Library/PrivateFrameworks/DesktopServicesPriv.framework/Versions/A/DesktopServicesPriv
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/HIToolbox
+0x000000000d140000 	/System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SpeechRecognition.framework/Versions/A/SpeechRecognition
+0x000000000d140000 	/usr/lib/libauto.dylib
+0x000000000d140000 	/usr/lib/libicucore.A.dylib
+0x000000000d140000 	/usr/lib/libxml2.2.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreUI.framework/Versions/A/CoreUI
+0x000000000d140000 	/System/Library/Frameworks/CoreAudio.framework/Versions/A/CoreAudio
+0x000000000d140000 	/System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration
+0x000000000d140000 	/usr/lib/liblangid.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/MultitouchSupport.framework/Versions/A/MultitouchSupport
+0x000000000d140000 	/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
+0x000000000d140000 	/usr/lib/libDiagnosticMessagesClient.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
+0x000000000d140000 	/System/Library/PrivateFrameworks/PerformanceAnalysis.framework/Versions/A/PerformanceAnalysis
+0x000000000d140000 	/System/Library/PrivateFrameworks/GenerationalStorage.framework/Versions/A/GenerationalStorage
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL
+0x000000000d140000 	/System/Library/PrivateFrameworks/Sharing.framework/Versions/A/Sharing
+0x000000000d140000 	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics
+0x000000000d140000 	/System/Library/Frameworks/CoreText.framework/Versions/A/CoreText
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO
+0x000000000d140000 	/usr/lib/libextension.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/Backup.framework/Versions/A/Backup
+0x000000000d140000 	/usr/lib/libarchive.2.dylib
+0x000000000d140000 	/System/Library/Frameworks/CFNetwork.framework/Versions/A/CFNetwork
+0x000000000d140000 	/System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration
+0x000000000d140000 	/usr/lib/libCRFSuite.dylib
+0x000000000d140000 	/usr/lib/libc++.1.dylib
+0x000000000d140000 	/usr/lib/libc++abi.dylib
+0x000000000d140000 	/usr/lib/system/libcache.dylib
+0x000000000d140000 	/usr/lib/system/libcommonCrypto.dylib
+0x000000000d140000 	/usr/lib/system/libcompiler_rt.dylib
+0x000000000d140000 	/usr/lib/system/libcopyfile.dylib
+0x000000000d140000 	/usr/lib/system/libcorecrypto.dylib
+0x000000000d140000 	/usr/lib/system/libdispatch.dylib
+0x000000000d140000 	/usr/lib/system/libdyld.dylib
+0x000000000d140000 	/usr/lib/system/libkeymgr.dylib
+0x000000000d140000 	/usr/lib/system/liblaunch.dylib
+0x000000000d140000 	/usr/lib/system/libmacho.dylib
+0x000000000d140000 	/usr/lib/system/libquarantine.dylib
+0x000000000d140000 	/usr/lib/system/libremovefile.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_asl.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_blocks.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_c.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_configuration.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_coreservices.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_coretls.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_dnssd.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_info.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_kernel.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_m.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_malloc.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_network.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_networkextension.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_notify.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_platform.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_pthread.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_sandbox.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_secinit.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_stats.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_trace.dylib
+0x000000000d140000 	/usr/lib/system/libunc.dylib
+0x000000000d140000 	/usr/lib/system/libunwind.dylib
+0x000000000d140000 	/usr/lib/system/libxpc.dylib
+0x000000000d140000 	/usr/lib/libbz2.1.0.dylib
+0x000000000d140000 	/usr/lib/liblzma.5.dylib
+0x000000000d140000 	/usr/lib/libbsm.0.dylib
+0x000000000d140000 	/usr/lib/libsqlite3.dylib
+0x000000000d140000 	/usr/lib/system/libkxld.dylib
+0x000000000d140000 	/usr/lib/libxar.1.dylib
+0x000000000d140000 	/usr/lib/libpam.2.dylib
+0x000000000d140000 	/usr/lib/libOpenScriptingUtil.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/FSEvents.framework/Versions/A/FSEvents
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/CarbonCore.framework/Versions/A/CarbonCore
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/Metadata.framework/Versions/A/Metadata
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/OSServices.framework/Versions/A/OSServices
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SearchKit.framework/Versions/A/SearchKit
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/AE.framework/Versions/A/AE
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/LaunchServices
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/DictionaryServices.framework/Versions/A/DictionaryServices
+0x000000000d140000 	/System/Library/Frameworks/NetFS.framework/Versions/A/NetFS
+0x000000000d140000 	/System/Library/PrivateFrameworks/NetAuth.framework/Versions/A/NetAuth
+0x000000000d140000 	/System/Library/PrivateFrameworks/login.framework/Versions/A/Frameworks/loginsupport.framework/Versions/A/loginsupport
+0x000000000d140000 	/System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC
+0x000000000d140000 	/usr/lib/libmecabra.dylib
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/ATS
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ColorSync.framework/Versions/A/ColorSync
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/HIServices.framework/Versions/A/HIServices
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/LangAnalysis.framework/Versions/A/LangAnalysis
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/PrintCore.framework/Versions/A/PrintCore
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/QD.framework/Versions/A/QD
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/SpeechSynthesis.framework/Versions/A/SpeechSynthesis
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Accelerate
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vImage.framework/Versions/A/vImage
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/vecLib
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvDSP.dylib
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvMisc.dylib
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLAPACK.dylib
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLinearAlgebra.dylib
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libFontParser.dylib
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libFontRegistry.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/AppleVPA.framework/Versions/A/AppleVPA
+0x000000000d140000 	/System/Library/PrivateFrameworks/AppleJPEG.framework/Versions/A/AppleJPEG
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJPEG.dylib
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libTIFF.dylib
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libPng.dylib
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libGIF.dylib
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJP2.dylib
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libRadiance.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreVideo.framework/Versions/A/CoreVideo
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLU.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGFXShared.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLImage.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCVMSPluginSupport.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCoreVMClient.dylib
+0x000000000d140000 	/usr/lib/libcups.2.dylib
+0x000000000d140000 	/System/Library/Frameworks/Kerberos.framework/Versions/A/Kerberos
+0x000000000d140000 	/System/Library/Frameworks/GSS.framework/Versions/A/GSS
+0x000000000d140000 	/usr/lib/libresolv.9.dylib
+0x000000000d140000 	/usr/lib/libiconv.2.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/Heimdal.framework/Versions/A/Heimdal
+0x000000000d140000 	/usr/lib/libheimdal-asn1.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenDirectory.framework/Versions/A/OpenDirectory
+0x000000000d140000 	/System/Library/PrivateFrameworks/CommonAuth.framework/Versions/A/CommonAuth
+0x000000000d140000 	/System/Library/Frameworks/OpenDirectory.framework/Versions/A/Frameworks/CFOpenDirectory.framework/Versions/A/CFOpenDirectory
+0x000000000d140000 	/System/Library/Frameworks/SecurityFoundation.framework/Versions/A/SecurityFoundation
+0x000000000d140000 	/System/Library/PrivateFrameworks/LanguageModeling.framework/Versions/A/LanguageModeling
+0x000000000d140000 	/usr/lib/libcmph.dylib
+0x000000000d140000 	/System/Library/Frameworks/ServiceManagement.framework/Versions/A/ServiceManagement
+0x000000000d140000 	/usr/lib/libxslt.1.dylib
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Ink.framework/Versions/A/Ink
+0x000000000d140000 	/System/Library/Frameworks/QuartzCore.framework/Versions/A/Frameworks/CoreImage.framework/Versions/A/CoreImage
+0x000000000d140000 	/System/Library/PrivateFrameworks/CrashReporterSupport.framework/Versions/A/CrashReporterSupport
+0x000000000d140000 	/System/Library/Frameworks/OpenCL.framework/Versions/A/OpenCL
+0x000000000d140000 	/System/Library/PrivateFrameworks/FaceCore.framework/Versions/A/FaceCore
+0x000000000d140000 	/System/Library/PrivateFrameworks/Ubiquity.framework/Versions/A/Ubiquity
+0x000000000d140000 	/System/Library/PrivateFrameworks/IconServices.framework/Versions/A/IconServices
+0x000000000d140000 	/System/Library/PrivateFrameworks/ChunkingLibrary.framework/Versions/A/ChunkingLibrary
+0x000000000d140000 	/System/Library/PrivateFrameworks/Apple80211.framework/Versions/A/Apple80211
+0x000000000d140000 	/System/Library/Frameworks/CoreWLAN.framework/Versions/A/CoreWLAN
+0x000000000d140000 	/System/Library/Frameworks/IOBluetooth.framework/Versions/A/IOBluetooth
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreWiFi.framework/Versions/A/CoreWiFi
+0x000000000d140000 	/System/Library/Frameworks/CoreBluetooth.framework/Versions/A/CoreBluetooth
+0x000000000d140000 	/System/Library/PrivateFrameworks/DebugSymbols.framework/Versions/A/DebugSymbols
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/CoreSymbolication
+0x000000000d140000 	/System/Library/PrivateFrameworks/Symbolication.framework/Versions/A/Symbolication
+0x000000000d140000 	/System/Library/PrivateFrameworks/SpeechRecognitionCore.framework/Versions/A/SpeechRecognitionCore
+0x000000010c641000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/server/libjvm.dylib
+0x000000000d140000 	/usr/lib/libstdc++.6.dylib
+0x000000010d577000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libverify.dylib
+0x000000010d585000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libjava.dylib
+0x000000010d5c3000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libzip.dylib
+0x0000000123f50000 	/System/Library/Frameworks/JavaVM.framework/Frameworks/JavaRuntimeSupport.framework/JavaRuntimeSupport
+0x0000000123f66000 	/System/Library/Frameworks/JavaVM.framework/Versions/A/Frameworks/JavaNativeFoundation.framework/Versions/A/JavaNativeFoundation
+0x0000000123f7a000 	/System/Library/Frameworks/JavaVM.framework/Versions/A/JavaVM
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Carbon
+0x000000010d5f5000 	/System/Library/PrivateFrameworks/JavaLaunching.framework/Versions/A/JavaLaunching
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/CommonPanels.framework/Versions/A/CommonPanels
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Help.framework/Versions/A/Help
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/ImageCapture.framework/Versions/A/ImageCapture
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/OpenScripting.framework/Versions/A/OpenScripting
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Print.framework/Versions/A/Print
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SecurityHI.framework/Versions/A/SecurityHI
+0x0000000125e0a000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libawt.dylib
+0x0000000125eb9000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/./libmlib_image.dylib
+0x0000000125f85000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libawt_lwawt.dylib
+0x0000000126038000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/./libosxapp.dylib
+0x000000000d140000 	/System/Library/Frameworks/ExceptionHandling.framework/Versions/A/ExceptionHandling
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreServicesInternal.framework/Versions/A/CoreServicesInternal
+0x000000000d140000 	/System/Library/PrivateFrameworks/CloudDocs.framework/Versions/A/CloudDocs
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreDuet.framework/Versions/A/CoreDuet
+0x000000000d140000 	/System/Library/Frameworks/CloudKit.framework/Versions/A/CloudKit
+0x000000000d140000 	/System/Library/PrivateFrameworks/ProtocolBuffer.framework/Versions/A/ProtocolBuffer
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreDuetDaemonProtocol.framework/Versions/A/CoreDuetDaemonProtocol
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreDuetDebugLogging.framework/Versions/A/CoreDuetDebugLogging
+0x000000000d140000 	/System/Library/Frameworks/CoreLocation.framework/Versions/A/CoreLocation
+0x000000000d140000 	/System/Library/Frameworks/Accounts.framework/Versions/A/Accounts
+0x000000000d140000 	/System/Library/PrivateFrameworks/ApplePushService.framework/Versions/A/ApplePushService
+0x000000000d140000 	/System/Library/PrivateFrameworks/GeoServices.framework/Versions/A/GeoServices
+0x000000000d140000 	/System/Library/PrivateFrameworks/OAuth.framework/Versions/A/OAuth
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreDaemon.framework/Versions/B/CoreDaemon
+0x000000000d140000 	/usr/lib/libcrypto.0.9.8.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/AppleSRP.framework/Versions/A/AppleSRP
+0x000000000d140000 	/System/Library/PrivateFrameworks/TrustEvaluationAgent.framework/Versions/A/TrustEvaluationAgent
+0x000000000d140000 	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Resources/libCGCMS.A.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Resources/libRIP.A.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Resources/libCGXType.A.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenCL.framework/Versions/A/Libraries/libcldcpuengine.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/DiskImages.framework/Versions/A/DiskImages
+0x000000000d140000 	/System/Library/Frameworks/DiscRecording.framework/Versions/A/DiscRecording
+0x000000000d140000 	/usr/lib/libcsfde.dylib
+0x000000000d140000 	/usr/lib/libcurl.4.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/MediaKit.framework/Versions/A/MediaKit
+0x000000000d140000 	/System/Library/PrivateFrameworks/ProtectedCloudStorage.framework/Versions/A/ProtectedCloudStorage
+0x000000000d140000 	/usr/lib/libCoreStorage.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/EFILogin.framework/Versions/A/EFILogin
+0x000000000d140000 	/usr/lib/libutil.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/FindMyDevice.framework/Versions/A/FindMyDevice
+0x000000000d140000 	/System/Library/Frameworks/LDAP.framework/Versions/A/LDAP
+0x000000000d140000 	/usr/lib/libsasl2.2.dylib
+0x0000000128b55000 	cl_kernels
+0x0000000128b57000 	/System/Library/Frameworks/OpenCL.framework/Versions/A/Libraries/ImageFormats/unorm8_bgra.dylib
+0x0000000128b46000 	cl_kernels
+0x000000000d140000 	/System/Library/PrivateFrameworks/FamilyControls.framework/Versions/A/FamilyControls
+0x000000000d140000 	/System/Library/PrivateFrameworks/CommerceKit.framework/Versions/A/Frameworks/CommerceCore.framework/Versions/A/CommerceCore
+0x000000000d140000 	/System/Library/PrivateFrameworks/SystemAdministration.framework/Versions/A/SystemAdministration
+0x000000000d140000 	/System/Library/PrivateFrameworks/AppContainer.framework/Versions/A/AppContainer
+0x000000000d140000 	/System/Library/PrivateFrameworks/SecCodeWrapper.framework/Versions/A/SecCodeWrapper
+0x000000000d140000 	/System/Library/Frameworks/DirectoryService.framework/Versions/A/DirectoryService
+0x000000000d140000 	/System/Library/PrivateFrameworks/LoginUIKit.framework/Versions/A/Frameworks/LoginUICore.framework/Versions/A/LoginUICore
+0x000000000d140000 	/usr/lib/libodfde.dylib
+0x0000000129d1a000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libfontmanager.dylib
+0x0000000129d81000 	/Users/ShantalOlono/Life/slick/liblwjgl.dylib
+0x000000012808d000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libjawt.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Resources/GLEngine.bundle/GLEngine
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLProgrammability.dylib
+0x0000000000000000 	/System/Library/Extensions/AppleIntelHD4000GraphicsGLDriver.bundle/Contents/MacOS/AppleIntelHD4000GraphicsGLDriver
+0x000000000d140000 	/System/Library/PrivateFrameworks/IOAccelerator.framework/Versions/A/IOAccelerator
+0x000000000d140000 	/System/Library/PrivateFrameworks/GPUSupport.framework/Versions/A/Libraries/libGPUSupportMercury.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Resources/GLRendererFloat.bundle/GLRendererFloat
+0x000000012a607000 	/Users/ShantalOlono/Life/slick/libjinput-osx.dylib
+0x000000012a60c000 	/System/Library/Extensions/IOHIDFamily.kext/Contents/PlugIns/IOHIDLib.plugin/Contents/MacOS/IOHIDLib
+0x00000001387af000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libnet.dylib
+0x00000001386f5000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libnio.dylib
+
+VM Arguments:
+jvm_args: -Djava.library.path=/Users/ShantalOlono/Life/slick -Dfile.encoding=UTF-8 
+java_command: main.java.edu.asu.cst316.Game
+java_class_path (initial): /Users/ShantalOlono/Life/bin:/Users/ShantalOlono/Life/jar/jacocoagent.jar:/Users/ShantalOlono/Life/jar/jacocoant.jar:/Users/ShantalOlono/Life/jar/junit.jar:/Users/ShantalOlono/Life/jar/org.jacoco.agent-0.7.4.201502262128.jar:/Users/ShantalOlono/Life/jar/org.jacoco.ant-0.7.4.201502262128.jar:/Users/ShantalOlono/Life/jar/org.jacoco.core-0.7.4.201502262128.jar:/Users/ShantalOlono/Life/jar/org.jacoco.report-0.7.4.201502262128.jar:/Users/ShantalOlono/Life/slick/lib/commons-math3-3.3.jar:/Users/ShantalOlono/Life/slick/lib/ibxm.jar:/Users/ShantalOlono/Life/slick/lib/jinput.jar:/Users/ShantalOlono/Life/slick/lib/jnlp.jar:/Users/ShantalOlono/Life/slick/lib/jogg-0.0.7.jar:/Users/ShantalOlono/Life/slick/lib/jorbis-0.0.15.jar:/Users/ShantalOlono/Life/slick/lib/lwjgl_util_applet.jar:/Users/ShantalOlono/Life/slick/lib/lwjgl_util.jar:/Users/ShantalOlono/Life/slick/lib/lwjgl.jar:/Users/ShantalOlono/Life/slick/lib/natives-linux.jar:/Users/ShantalOlono/Life/slick/lib/natives-mac.jar:/Users/ShantalOlono/Life/slick/lib/natives-windows.jar:/Users/ShantalOlono/Life/slick/lib/Pack200Task.jar:/Users/ShantalOlono/Life/slick/lib/slick-examples.jar:/Users/ShantalOlono/Life/slick/lib/slick.jar:/Users/ShantalOlono/Life/slick/lib/tinylinepp.jar
+Launcher Type: SUN_STANDARD
+
+Environment Variables:
+PATH=/usr/bin:/bin:/usr/sbin:/sbin
+SHELL=/bin/bash
+
+Signal Handlers:
+SIGSEGV: [libjvm.dylib+0x57a0e7], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_ONSTACK|SA_RESTART|SA_SIGINFO
+SIGBUS: [libjvm.dylib+0x57a0e7], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGFPE: [libjvm.dylib+0x45af24], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGPIPE: [libjvm.dylib+0x45af24], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGXFSZ: [libjvm.dylib+0x45af24], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGILL: [libjvm.dylib+0x45af24], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGUSR1: SIG_DFL, sa_mask[0]=00000000000000000000000000000000, sa_flags=none
+SIGUSR2: [libjvm.dylib+0x45aa42], sa_mask[0]=00100000000000000000000000000000, sa_flags=SA_RESTART|SA_SIGINFO
+SIGHUP: [libjvm.dylib+0x459015], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGINT: [libjvm.dylib+0x459015], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGTERM: [libjvm.dylib+0x459015], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGQUIT: [libjvm.dylib+0x459015], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+
+
+---------------  S Y S T E M  ---------------
+
+OS:Bsduname:Darwin 14.1.0 Darwin Kernel Version 14.1.0: Mon Dec 22 23:10:38 PST 2014; root:xnu-2782.10.72~2/RELEASE_X86_64 x86_64
+rlimit: STACK 8192k, CORE 0k, NPROC 709, NOFILE 10240, AS infinity
+load average:2.90 2.51 2.27
+
+CPU:total 4 (2 cores per cpu, 2 threads per core) family 6 model 58 stepping 9, cmov, cx8, fxsr, mmx, sse, sse2, sse3, ssse3, sse4.1, sse4.2, popcnt, avx, aes, clmul, erms, ht, tsc, tscinvbit, tscinv
+
+Memory: 4k page, physical 8388608k(73460k free)
+
+/proc/meminfo:
+
+
+vm_info: Java HotSpot(TM) 64-Bit Server VM (25.31-b07) for bsd-amd64 JRE (1.8.0_31-b13), built on Dec 17 2014 20:45:36 by "java_re" with gcc 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2336.11.00)
+
+time: Mon Apr 20 18:16:46 2015
+elapsed time: 16 seconds (0d 0h 0m 16s)
+

--- a/hs_err_pid9096.log
+++ b/hs_err_pid9096.log
@@ -1,0 +1,627 @@
+#
+# A fatal error has been detected by the Java Runtime Environment:
+#
+#  SIGSEGV (0xb) at pc=0x00007fff953d38f2, pid=9096, tid=1811
+#
+# JRE version: Java(TM) SE Runtime Environment (8.0_31-b13) (build 1.8.0_31-b13)
+# Java VM: Java HotSpot(TM) 64-Bit Server VM (25.31-b07 mixed mode bsd-amd64 compressed oops)
+# Problematic frame:
+# C  [libGPUSupportMercury.dylib+0xb8f2]  gldAttachDrawable+0x60
+#
+# Failed to write core dump. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
+#
+# If you would like to submit a bug report, please visit:
+#   http://bugreport.java.com/bugreport/crash.jsp
+# The crash happened outside the Java Virtual Machine in native code.
+# See problematic frame for where to report the bug.
+#
+
+---------------  T H R E A D  ---------------
+
+Current thread (0x00007ff8c409a800):  JavaThread "AppKit Thread" daemon [_thread_in_native, id=1811, stack(0x00007fff533e3000,0x00007fff53be3000)]
+
+siginfo: si_signo: 11 (SIGSEGV), si_code: 0 (unknown), si_addr: 0x0000000000000000
+
+Registers:
+RAX=0x8000000000000000, RBX=0x000000000000271e, RCX=0x0000000000000000, RDX=0x00007ff8c5d16808
+RSP=0x00007fff53bdc420, RBP=0x00007fff53bdc520, RSI=0x0000000000000050, RDI=0x00007fff7dc46070
+R8 =0x00007ff8c600aa60, R9 =0x00007ff8c6000000, R10=0x000000000000003c, R11=0x0000000000000206
+R12=0x0000000000002718, R13=0x00007ff8c41c4200, R14=0x0000000000000050, R15=0x0000000000000000
+RIP=0x00007fff953d38f2, EFLAGS=0x0000000000010212, ERR=0x0000000000000000
+  TRAPNO=0x000000000000000d
+
+Top of Stack: (sp=0x00007fff53bdc420)
+0x00007fff53bdc420:   00007fff53bdc494 00007ff8c3528520
+0x00007fff53bdc430:   ffffffffffffffff 0000206000000040
+0x00007fff53bdc440:   00007ff8c3528538 00007fff9bcbd64f
+0x00007fff53bdc450:   0000000000000000 8000000000000000
+0x00007fff53bdc460:   0000000300000003 00007fff53bdc5a8
+0x00007fff53bdc470:   00007fff53bdc534 000000000004697f
+0x00007fff53bdc480:   00007fff53bdc52c 00007fff53bdc530
+0x00007fff53bdc490:   00007fff53bdc510 00007fff98cbbfa6
+0x00007fff53bdc4a0:   0000000000000000 0000000000001fd6
+0x00007fff53bdc4b0:   0000003400001200 0000040b00000000
+0x00007fff53bdc4c0:   00007fff53bdc4f0 00007fff98c6beac
+0x00007fff53bdc4d0:   00007fff53bdc520 0000000000001fd6
+0x00007fff53bdc4e0:   00000000042730c0 0000000024838754
+0x00007fff53bdc4f0:   b0000a340f321f27 00007ff8c6000c00
+0x00007fff53bdc500:   0000000000002718 0000000000000000
+0x00007fff53bdc510:   0000000000000050 0000000000000000
+0x00007fff53bdc520:   00007fff53bdc570 00007fff918197e8
+0x00007fff53bdc530:   00007ff8c600aa60 0000000000000000
+0x00007fff53bdc540:   00007ff8c5d16808 00007ff8c3653900
+0x00007fff53bdc550:   0000000000000000 00007ff8c5100750
+0x00007fff53bdc560:   00007ff8c50fe800 00007fff7dc46070
+0x00007fff53bdc570:   00007fff53bdc660 00007fff95ae77ac
+0x00007fff53bdc580:   4089000000000000 406e000000000000
+0x00007fff53bdc590:   4053800000000000 4089000000000000
+0x00007fff53bdc5a0:   4083700000000000 0000000000000000
+0x00007fff53bdc5b0:   4036000000000000 4089000000000000
+0x00007fff53bdc5c0:   4082c00000000000 0000000000000000
+0x00007fff53bdc5d0:   0000000000000000 0000000000000001
+0x00007fff53bdc5e0:   00007ff8c5d16808 0000000000000001
+0x00007fff53bdc5f0:   00007fff53bdc660 00007fff95aec64c
+0x00007fff53bdc600:   0000000100000003 00007ff8c5100750
+0x00007fff53bdc610:   00007ff8c5100688 000000029b94ffff 
+
+Instructions: (pc=0x00007fff953d38f2)
+0x00007fff953d38d2:   48 85 d2 b8 01 00 00 00 bb 15 27 00 00 0f 44 d8
+0x00007fff953d38e2:   e9 7f 01 00 00 49 8b 45 08 48 89 85 38 ff ff ff
+0x00007fff953d38f2:   48 8b 00 48 89 85 30 ff ff ff 83 fe 4f 0f 8f fd
+0x00007fff953d3902:   00 00 00 48 89 d0 bb 15 27 00 00 83 fe 35 0f 84 
+
+Register to memory mapping:
+
+RAX=0x8000000000000000 is an unknown value
+RBX=0x000000000000271e is an unknown value
+RCX=0x0000000000000000 is an unknown value
+RDX=0x00007ff8c5d16808 is an unknown value
+RSP=0x00007fff53bdc420 is pointing into the stack for thread: 0x00007ff8c409a800
+RBP=0x00007fff53bdc520 is pointing into the stack for thread: 0x00007ff8c409a800
+RSI=0x0000000000000050 is an unknown value
+RDI=0x00007fff7dc46070: __stack_chk_guard+0 in /usr/lib/system/libsystem_c.dylib at 0x00007fff91534000
+R8 =0x00007ff8c600aa60 is an unknown value
+R9 =0x00007ff8c6000000 is an unknown value
+R10=0x000000000000003c is an unknown value
+R11=0x0000000000000206 is an unknown value
+R12=0x0000000000002718 is an unknown value
+R13=0x00007ff8c41c4200 is an unknown value
+R14=0x0000000000000050 is an unknown value
+R15=0x0000000000000000 is an unknown value
+
+
+Stack: [0x00007fff533e3000,0x00007fff53be3000],  sp=0x00007fff53bdc420,  free space=8165k
+Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
+C  [libGPUSupportMercury.dylib+0xb8f2]  gldAttachDrawable+0x60
+C  [GLEngine+0x167e8]  gliAttachDrawableWithOptions+0x101
+C  [OpenGL+0x37ac]  glcGetIOAccelService+0xe03
+C  [OpenGL+0x73f3]  CGLSetPBuffer+0xb90
+C  [OpenGL+0x7716]  CGLSetSurface+0x124
+C  [AppKit+0x57e567]  NSOpenGLContextAttachOnScreenViewSurface+0x109
+C  [AppKit+0x2c669b]  -[NSOpenGLContext setView:]+0x83
+C  [liblwjgl.dylib+0xa586]  -[MacOSXOpenGLView lockFocus]+0x76
+C  [AppKit+0x14e3c5]  -[NSView _recursiveDisplayRectIfNeededIgnoringOpacity:isVisibleRect:rectIsVisibleRectForView:topView:]+0x740
+C  [AppKit+0x14f420]  -[NSView _recursiveDisplayRectIfNeededIgnoringOpacity:isVisibleRect:rectIsVisibleRectForView:topView:]+0x179b
+C  [AppKit+0x14d773]  -[NSThemeFrame _recursiveDisplayRectIfNeededIgnoringOpacity:isVisibleRect:rectIsVisibleRectForView:topView:]+0x14d
+C  [AppKit+0x14a2cb]  -[NSView _displayRectIgnoringOpacity:isVisibleRect:rectIsVisibleRectForView:]+0xac9
+C  [AppKit+0x128e2d]  -[NSView displayIfNeeded]+0x754
+C  [AppKit+0x1461c5]  -[NSWindow displayIfNeeded]+0xe8
+C  [AppKit+0x183322]  _handleWindowNeedsDisplayOrLayoutOrUpdateConstraints+0x3a8
+C  [Foundation+0x66db3]  __NSFireTimer+0x5f
+C  [CoreFoundation+0xb5b64]  __CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__+0x14
+C  [CoreFoundation+0xb57f3]  __CFRunLoopDoTimer+0x423
+C  [CoreFoundation+0x128dbd]  __CFRunLoopDoTimers+0x12d
+C  [CoreFoundation+0x72288]  __CFRunLoopRun+0x7e8
+C  [CoreFoundation+0x71858]  CFRunLoopRunSpecific+0x128
+C  [HIToolbox+0x2eaef]  RunCurrentEventLoopInMode+0xeb
+C  [HIToolbox+0x2e86a]  ReceiveNextEventCommon+0x1af
+C  [HIToolbox+0x2e6ab]  _BlockUntilNextEventMatchingListInModeWithFilter+0x47
+C  [AppKit+0x23f81]  _DPSNextEvent+0x3c4
+C  [AppKit+0x23730]  -[NSApplication nextEventMatchingMask:untilDate:inMode:dequeue:]+0xc2
+C  [libosxapp.dylib+0x242a]  -[NSApplicationAWT nextEventMatchingMask:untilDate:inMode:dequeue:]+0x7c
+C  [AppKit+0x17593]  -[NSApplication run]+0x252
+C  [libosxapp.dylib+0x223e]  +[NSApplicationAWT runAWTLoopWithApp:]+0x9c
+C  [libawt_lwawt.dylib+0x4494f]  -[AWTStarter starter:]+0x389
+C  [Foundation+0x65cdc]  __NSThreadPerformPerform+0x125
+C  [CoreFoundation+0x80681]  __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__+0x11
+C  [CoreFoundation+0x7280d]  __CFRunLoopDoSources0+0x10d
+C  [CoreFoundation+0x71e3f]  __CFRunLoopRun+0x39f
+C  [CoreFoundation+0x71858]  CFRunLoopRunSpecific+0x128
+C  [java+0x56cc]  CreateExecutionEnvironment+0x367
+C  [java+0x165c]  JLI_Launch+0x7a0
+C  [java+0x768a]  main+0x65
+C  [java+0xeb4]  start+0x34
+C  0x0000000000000006
+
+
+---------------  P R O C E S S  ---------------
+
+Java Threads: ( => current thread )
+  0x00007ff8c42ea000 JavaThread "AWT-Shutdown" [_thread_blocked, id=29195, stack(0x0000000126e8c000,0x0000000126f8c000)]
+  0x00007ff8c39d5800 JavaThread "Java2D Disposer" daemon [_thread_blocked, id=60167, stack(0x00000001381b6000,0x00000001382b6000)]
+  0x00007ff8c4974000 JavaThread "Java2D Queue Flusher" daemon [_thread_blocked, id=60423, stack(0x000000013781a000,0x000000013791a000)]
+=>0x00007ff8c409a800 JavaThread "AppKit Thread" daemon [_thread_in_native, id=1811, stack(0x00007fff533e3000,0x00007fff53be3000)]
+  0x00007ff8c5000000 JavaThread "Service Thread" daemon [_thread_blocked, id=18179, stack(0x0000000125670000,0x0000000125770000)]
+  0x00007ff8c4831800 JavaThread "C1 CompilerThread2" daemon [_thread_blocked, id=17667, stack(0x000000012556d000,0x000000012566d000)]
+  0x00007ff8c481f800 JavaThread "C2 CompilerThread1" daemon [_thread_blocked, id=17155, stack(0x000000012546a000,0x000000012556a000)]
+  0x00007ff8c4027800 JavaThread "C2 CompilerThread0" daemon [_thread_blocked, id=16643, stack(0x0000000125367000,0x0000000125467000)]
+  0x00007ff8c5015800 JavaThread "Signal Dispatcher" daemon [_thread_blocked, id=16147, stack(0x0000000125264000,0x0000000125364000)]
+  0x00007ff8c500e800 JavaThread "Finalizer" daemon [_thread_blocked, id=11523, stack(0x0000000123923000,0x0000000123a23000)]
+  0x00007ff8c4025800 JavaThread "Reference Handler" daemon [_thread_blocked, id=11011, stack(0x0000000123820000,0x0000000123920000)]
+  0x00007ff8c5001800 JavaThread "main" [_thread_in_native, id=4867, stack(0x000000010d052000,0x000000010d152000)]
+
+Other Threads:
+  0x00007ff8c3833000 VMThread [stack: 0x000000012371d000,0x000000012381d000] [id=10499]
+  0x00007ff8c5001000 WatcherThread [stack: 0x0000000125773000,0x0000000125873000] [id=18691]
+
+VM state:not at safepoint (normal execution)
+
+VM Mutex/Monitor currently owned by a thread: None
+
+Heap:
+ PSYoungGen      total 273920K, used 67769K [0x0000000795580000, 0x00000007b0680000, 0x00000007c0000000)
+  eden space 264192K, 24% used [0x0000000795580000,0x00000007995da6e8,0x00000007a5780000)
+  from space 9728K, 19% used [0x00000007a5780000,0x00000007a5954020,0x00000007a6100000)
+  to   space 10240K, 0% used [0x00000007afc80000,0x00000007afc80000,0x00000007b0680000)
+ ParOldGen       total 87552K, used 11345K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 12% used [0x0000000740000000,0x0000000740b14748,0x0000000745580000)
+ Metaspace       used 10331K, capacity 10465K, committed 10624K, reserved 1058816K
+  class space    used 1070K, capacity 1117K, committed 1152K, reserved 1048576K
+
+Card table byte_map: [0x000000011cdc0000,0x000000011d1c1000] byte_map_base: 0x00000001193c0000
+
+Marking Bits: (ParMarkBitMap*) 0x000000010c9b9410
+ Begin Bits: [0x000000011d878000, 0x000000011f878000)
+ End Bits:   [0x000000011f878000, 0x0000000121878000)
+
+Polling page: 0x000000010d196000
+
+CodeCache: size=245760Kb used=4904Kb max_used=4904Kb free=240855Kb
+ bounds [0x000000010da00000, 0x000000010dee0000, 0x000000011ca00000]
+ total_blobs=1808 nmethods=1280 adapters=443
+ compilation: enabled
+
+Compilation events (10 events):
+Event: 14.854 Thread 0x00007ff8c4831800 1276       3       main.java.edu.asu.cst316.GameMain::update (1874 bytes)
+Event: 14.869 Thread 0x00007ff8c4831800 nmethod 1276 0x000000010dea9550 code [0x000000010deaa820, 0x000000010deb7908]
+Event: 14.869 Thread 0x00007ff8c4831800 1277       3       org.newdawn.slick.Input::isMousePressed (20 bytes)
+Event: 14.869 Thread 0x00007ff8c4831800 nmethod 1277 0x000000010de89e90 code [0x000000010de8a000, 0x000000010de8a1f0]
+Event: 14.869 Thread 0x00007ff8c4831800 1278       3       main.java.edu.asu.cst316.GameMain::render (803 bytes)
+Event: 14.878 Thread 0x00007ff8c4831800 nmethod 1278 0x000000010debfb90 code [0x000000010dec09e0, 0x000000010dec94f8]
+Event: 15.371 Thread 0x00007ff8c4831800 1279       3       java.nio.HeapByteBuffer::putLong (21 bytes)
+Event: 15.371 Thread 0x00007ff8c4831800 nmethod 1279 0x000000010de8b910 code [0x000000010de8baa0, 0x000000010de8be68]
+Event: 15.371 Thread 0x00007ff8c4831800 1280       3       java.nio.Bits::putLong (21 bytes)
+Event: 15.371 Thread 0x00007ff8c4831800 nmethod 1280 0x000000010de8b4d0 code [0x000000010de8b640, 0x000000010de8b838]
+
+GC Heap History (10 events):
+Event: 7.215 GC heap before
+{Heap before GC invocations=5 (full 0):
+ PSYoungGen      total 71680K, used 70832K [0x0000000795580000, 0x000000079a080000, 0x00000007c0000000)
+  eden space 66560K, 100% used [0x0000000795580000,0x0000000799680000,0x0000000799680000)
+  from space 5120K, 83% used [0x0000000799b80000,0x0000000799fac030,0x000000079a080000)
+  to   space 5120K, 0% used [0x0000000799680000,0x0000000799680000,0x0000000799b80000)
+ ParOldGen       total 87552K, used 6178K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 7% used [0x0000000740000000,0x0000000740608960,0x0000000745580000)
+ Metaspace       used 10156K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1066K, capacity 1117K, committed 1152K, reserved 1048576K
+Event: 7.222 GC heap after
+Heap after GC invocations=5 (full 0):
+ PSYoungGen      total 71680K, used 5088K [0x0000000795580000, 0x000000079e880000, 0x00000007c0000000)
+  eden space 66560K, 0% used [0x0000000795580000,0x0000000795580000,0x0000000799680000)
+  from space 5120K, 99% used [0x0000000799680000,0x0000000799b78050,0x0000000799b80000)
+  to   space 8704K, 0% used [0x000000079e000000,0x000000079e000000,0x000000079e880000)
+ ParOldGen       total 87552K, used 8446K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 9% used [0x0000000740000000,0x000000074083f990,0x0000000745580000)
+ Metaspace       used 10156K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1066K, capacity 1117K, committed 1152K, reserved 1048576K
+}
+Event: 7.483 GC heap before
+{Heap before GC invocations=6 (full 0):
+ PSYoungGen      total 71680K, used 71648K [0x0000000795580000, 0x000000079e880000, 0x00000007c0000000)
+  eden space 66560K, 100% used [0x0000000795580000,0x0000000799680000,0x0000000799680000)
+  from space 5120K, 99% used [0x0000000799680000,0x0000000799b78050,0x0000000799b80000)
+  to   space 8704K, 0% used [0x000000079e000000,0x000000079e000000,0x000000079e880000)
+ ParOldGen       total 87552K, used 8446K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 9% used [0x0000000740000000,0x000000074083f990,0x0000000745580000)
+ Metaspace       used 10161K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1066K, capacity 1117K, committed 1152K, reserved 1048576K
+Event: 7.489 GC heap after
+Heap after GC invocations=6 (full 0):
+ PSYoungGen      total 140800K, used 8208K [0x0000000795580000, 0x000000079ea80000, 0x00000007c0000000)
+  eden space 132096K, 0% used [0x0000000795580000,0x0000000795580000,0x000000079d680000)
+  from space 8704K, 94% used [0x000000079e000000,0x000000079e804070,0x000000079e880000)
+  to   space 9728K, 0% used [0x000000079d680000,0x000000079d680000,0x000000079e000000)
+ ParOldGen       total 87552K, used 8454K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 9% used [0x0000000740000000,0x0000000740841990,0x0000000745580000)
+ Metaspace       used 10161K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1066K, capacity 1117K, committed 1152K, reserved 1048576K
+}
+Event: 8.209 GC heap before
+{Heap before GC invocations=7 (full 0):
+ PSYoungGen      total 140800K, used 140304K [0x0000000795580000, 0x000000079ea80000, 0x00000007c0000000)
+  eden space 132096K, 100% used [0x0000000795580000,0x000000079d680000,0x000000079d680000)
+  from space 8704K, 94% used [0x000000079e000000,0x000000079e804070,0x000000079e880000)
+  to   space 9728K, 0% used [0x000000079d680000,0x000000079d680000,0x000000079e000000)
+ ParOldGen       total 87552K, used 8454K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 9% used [0x0000000740000000,0x0000000740841990,0x0000000745580000)
+ Metaspace       used 10173K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1066K, capacity 1117K, committed 1152K, reserved 1048576K
+Event: 8.217 GC heap after
+Heap after GC invocations=7 (full 0):
+ PSYoungGen      total 141824K, used 6656K [0x0000000795580000, 0x00000007a6a80000, 0x00000007c0000000)
+  eden space 132096K, 0% used [0x0000000795580000,0x0000000795580000,0x000000079d680000)
+  from space 9728K, 68% used [0x000000079d680000,0x000000079dd00060,0x000000079e000000)
+  to   space 9728K, 0% used [0x00000007a6100000,0x00000007a6100000,0x00000007a6a80000)
+ ParOldGen       total 87552K, used 10265K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 11% used [0x0000000740000000,0x0000000740a06738,0x0000000745580000)
+ Metaspace       used 10173K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1066K, capacity 1117K, committed 1152K, reserved 1048576K
+}
+Event: 8.875 GC heap before
+{Heap before GC invocations=8 (full 0):
+ PSYoungGen      total 141824K, used 138752K [0x0000000795580000, 0x00000007a6a80000, 0x00000007c0000000)
+  eden space 132096K, 100% used [0x0000000795580000,0x000000079d680000,0x000000079d680000)
+  from space 9728K, 68% used [0x000000079d680000,0x000000079dd00060,0x000000079e000000)
+  to   space 9728K, 0% used [0x00000007a6100000,0x00000007a6100000,0x00000007a6a80000)
+ ParOldGen       total 87552K, used 10265K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 11% used [0x0000000740000000,0x0000000740a06738,0x0000000745580000)
+ Metaspace       used 10178K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1066K, capacity 1117K, committed 1152K, reserved 1048576K
+Event: 8.878 GC heap after
+Heap after GC invocations=8 (full 0):
+ PSYoungGen      total 273920K, used 2560K [0x0000000795580000, 0x00000007a6a80000, 0x00000007c0000000)
+  eden space 264192K, 0% used [0x0000000795580000,0x0000000795580000,0x00000007a5780000)
+  from space 9728K, 26% used [0x00000007a6100000,0x00000007a6380020,0x00000007a6a80000)
+  to   space 9728K, 0% used [0x00000007a5780000,0x00000007a5780000,0x00000007a6100000)
+ ParOldGen       total 87552K, used 10297K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 11% used [0x0000000740000000,0x0000000740a0e738,0x0000000745580000)
+ Metaspace       used 10178K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1066K, capacity 1117K, committed 1152K, reserved 1048576K
+}
+Event: 10.138 GC heap before
+{Heap before GC invocations=9 (full 0):
+ PSYoungGen      total 273920K, used 266752K [0x0000000795580000, 0x00000007a6a80000, 0x00000007c0000000)
+  eden space 264192K, 100% used [0x0000000795580000,0x00000007a5780000,0x00000007a5780000)
+  from space 9728K, 26% used [0x00000007a6100000,0x00000007a6380020,0x00000007a6a80000)
+  to   space 9728K, 0% used [0x00000007a5780000,0x00000007a5780000,0x00000007a6100000)
+ ParOldGen       total 87552K, used 10297K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 11% used [0x0000000740000000,0x0000000740a0e738,0x0000000745580000)
+ Metaspace       used 10183K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1066K, capacity 1117K, committed 1152K, reserved 1048576K
+Event: 10.142 GC heap after
+Heap after GC invocations=9 (full 0):
+ PSYoungGen      total 273920K, used 1872K [0x0000000795580000, 0x00000007b0680000, 0x00000007c0000000)
+  eden space 264192K, 0% used [0x0000000795580000,0x0000000795580000,0x00000007a5780000)
+  from space 9728K, 19% used [0x00000007a5780000,0x00000007a5954020,0x00000007a6100000)
+  to   space 10240K, 0% used [0x00000007afc80000,0x00000007afc80000,0x00000007b0680000)
+ ParOldGen       total 87552K, used 11345K [0x0000000740000000, 0x0000000745580000, 0x0000000795580000)
+  object space 87552K, 12% used [0x0000000740000000,0x0000000740b14748,0x0000000745580000)
+ Metaspace       used 10183K, capacity 10337K, committed 10624K, reserved 1058816K
+  class space    used 1066K, capacity 1117K, committed 1152K, reserved 1048576K
+}
+
+Deoptimization events (10 events):
+Event: 3.066 Thread 0x00007ff8c5001800 Uncommon trap: reason=bimorphic action=maybe_recompile pc=0x000000010dc1c180 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 91
+Event: 3.066 Thread 0x00007ff8c5001800 Uncommon trap: reason=bimorphic action=maybe_recompile pc=0x000000010dc1c180 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 91
+Event: 3.066 Thread 0x00007ff8c5001800 Uncommon trap: reason=bimorphic action=maybe_recompile pc=0x000000010dc1d7e4 method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 91
+Event: 5.442 Thread 0x00007ff8c5001800 Uncommon trap: reason=class_check action=maybe_recompile pc=0x000000010dd1e85c method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 253
+Event: 5.442 Thread 0x00007ff8c5001800 Uncommon trap: reason=class_check action=maybe_recompile pc=0x000000010dd1e85c method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 253
+Event: 5.443 Thread 0x00007ff8c5001800 Uncommon trap: reason=class_check action=maybe_recompile pc=0x000000010dd1e85c method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 253
+Event: 5.443 Thread 0x00007ff8c5001800 Uncommon trap: reason=class_check action=maybe_recompile pc=0x000000010dd1e85c method=java.util.HashMap.putVal(ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object; @ 253
+Event: 8.498 Thread 0x00007ff8c5001800 Uncommon trap: reason=unloaded action=reinterpret pc=0x000000010ddeeef8 method=sun.font.CStrike$GlyphInfoCache.get(I)J @ 58
+Event: 8.573 Thread 0x00007ff8c5001800 Uncommon trap: reason=range_check action=make_not_entrant pc=0x000000010ddf73c4 method=java.awt.geom.AffineTransform.<init>([D)V @ 7
+Event: 9.852 Thread 0x00007ff8c5001800 Uncommon trap: reason=range_check action=make_not_entrant pc=0x000000010de2bf34 method=sun.font.CCharToGlyphMapper$Cache.get(I[C[I)V @ 345
+
+Internal exceptions (10 events):
+Event: 5.357 Thread 0x00007ff8c5001800 Exception <a 'java/security/PrivilegedActionException'> (0x0000000795cbf4a8) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 5.539 Thread 0x00007ff8c5001800 Exception <a 'java/security/PrivilegedActionException'> (0x00000007973260b0) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 5.679 Thread 0x00007ff8c5001800 Exception <a 'java/security/PrivilegedActionException'> (0x00000007967d78e8) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 5.683 Thread 0x00007ff8c5001800 Exception <a 'java/security/PrivilegedActionException'> (0x00000007967df7b8) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 6.607 Thread 0x00007ff8c5001800 Exception <a 'java/security/PrivilegedActionException'> (0x00000007967e95f8) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 6.608 Thread 0x00007ff8c5001800 Exception <a 'java/security/PrivilegedActionException'> (0x00000007967f01b0) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 6.609 Thread 0x00007ff8c5001800 Exception <a 'java/security/PrivilegedActionException'> (0x00000007967fb350) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 6.646 Thread 0x00007ff8c5001800 Exception <a 'java/security/PrivilegedActionException'> (0x00000007967ff440) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 9.727 Thread 0x00007ff8c5001800 Exception <a 'java/security/PrivilegedActionException'> (0x00000007a0ab4070) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+Event: 15.417 Thread 0x00007ff8c5001800 Exception <a 'java/security/PrivilegedActionException'> (0x0000000799405728) thrown at [/Users/java_re/workspace/8-2-build-macosx-x86_64/jdk8u31/2394/hotspot/src/share/vm/prims/jvm.cpp, line 1312]
+
+Events (10 events):
+Event: 12.118 loading class sun/awt/AppContext$PostShutdownEventRunnable
+Event: 12.118 loading class sun/awt/AppContext$PostShutdownEventRunnable done
+Event: 12.118 Executing VM operation: RevokeBias
+Event: 12.118 Executing VM operation: RevokeBias done
+Event: 12.118 loading class sun/awt/AWTAutoShutdown$1
+Event: 12.118 loading class sun/awt/AWTAutoShutdown$1 done
+Event: 12.118 Thread 0x00007ff8c38c1000 Thread exited: 0x00007ff8c38c1000
+Event: 12.686 Thread 0x00007ff8c42ea000 Thread added: 0x00007ff8c42ea000
+Event: 15.417 loading class org/lwjgl/opengl/CallbackUtil
+Event: 15.417 loading class org/lwjgl/opengl/CallbackUtil done
+
+
+Dynamic libraries:
+0x000000000d140000 	/System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa
+0x000000000d140000 	/System/Library/Frameworks/Security.framework/Versions/A/Security
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices
+0x000000000d140000 	/usr/lib/libz.1.dylib
+0x000000000d140000 	/usr/lib/libSystem.B.dylib
+0x000000000d140000 	/usr/lib/libobjc.A.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
+0x000000000d140000 	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation
+0x000000000d140000 	/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
+0x000000000d140000 	/System/Library/Frameworks/CoreData.framework/Versions/A/CoreData
+0x000000000d140000 	/System/Library/PrivateFrameworks/RemoteViewServices.framework/Versions/A/RemoteViewServices
+0x000000000d140000 	/System/Library/PrivateFrameworks/UIFoundation.framework/Versions/A/UIFoundation
+0x000000000d140000 	/System/Library/Frameworks/IOSurface.framework/Versions/A/IOSurface
+0x000000000d140000 	/System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox
+0x000000000d140000 	/System/Library/Frameworks/AudioUnit.framework/Versions/A/AudioUnit
+0x000000000d140000 	/System/Library/PrivateFrameworks/DataDetectorsCore.framework/Versions/A/DataDetectorsCore
+0x000000000d140000 	/System/Library/PrivateFrameworks/DesktopServicesPriv.framework/Versions/A/DesktopServicesPriv
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/HIToolbox
+0x000000000d140000 	/System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SpeechRecognition.framework/Versions/A/SpeechRecognition
+0x000000000d140000 	/usr/lib/libauto.dylib
+0x000000000d140000 	/usr/lib/libicucore.A.dylib
+0x000000000d140000 	/usr/lib/libxml2.2.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreUI.framework/Versions/A/CoreUI
+0x000000000d140000 	/System/Library/Frameworks/CoreAudio.framework/Versions/A/CoreAudio
+0x000000000d140000 	/System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration
+0x000000000d140000 	/usr/lib/liblangid.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/MultitouchSupport.framework/Versions/A/MultitouchSupport
+0x000000000d140000 	/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
+0x000000000d140000 	/usr/lib/libDiagnosticMessagesClient.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
+0x000000000d140000 	/System/Library/PrivateFrameworks/PerformanceAnalysis.framework/Versions/A/PerformanceAnalysis
+0x000000000d140000 	/System/Library/PrivateFrameworks/GenerationalStorage.framework/Versions/A/GenerationalStorage
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL
+0x000000000d140000 	/System/Library/PrivateFrameworks/Sharing.framework/Versions/A/Sharing
+0x000000000d140000 	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics
+0x000000000d140000 	/System/Library/Frameworks/CoreText.framework/Versions/A/CoreText
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO
+0x000000000d140000 	/usr/lib/libextension.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/Backup.framework/Versions/A/Backup
+0x000000000d140000 	/usr/lib/libarchive.2.dylib
+0x000000000d140000 	/System/Library/Frameworks/CFNetwork.framework/Versions/A/CFNetwork
+0x000000000d140000 	/System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration
+0x000000000d140000 	/usr/lib/libCRFSuite.dylib
+0x000000000d140000 	/usr/lib/libc++.1.dylib
+0x000000000d140000 	/usr/lib/libc++abi.dylib
+0x000000000d140000 	/usr/lib/system/libcache.dylib
+0x000000000d140000 	/usr/lib/system/libcommonCrypto.dylib
+0x000000000d140000 	/usr/lib/system/libcompiler_rt.dylib
+0x000000000d140000 	/usr/lib/system/libcopyfile.dylib
+0x000000000d140000 	/usr/lib/system/libcorecrypto.dylib
+0x000000000d140000 	/usr/lib/system/libdispatch.dylib
+0x000000000d140000 	/usr/lib/system/libdyld.dylib
+0x000000000d140000 	/usr/lib/system/libkeymgr.dylib
+0x000000000d140000 	/usr/lib/system/liblaunch.dylib
+0x000000000d140000 	/usr/lib/system/libmacho.dylib
+0x000000000d140000 	/usr/lib/system/libquarantine.dylib
+0x000000000d140000 	/usr/lib/system/libremovefile.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_asl.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_blocks.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_c.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_configuration.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_coreservices.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_coretls.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_dnssd.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_info.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_kernel.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_m.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_malloc.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_network.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_networkextension.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_notify.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_platform.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_pthread.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_sandbox.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_secinit.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_stats.dylib
+0x000000000d140000 	/usr/lib/system/libsystem_trace.dylib
+0x000000000d140000 	/usr/lib/system/libunc.dylib
+0x000000000d140000 	/usr/lib/system/libunwind.dylib
+0x000000000d140000 	/usr/lib/system/libxpc.dylib
+0x000000000d140000 	/usr/lib/libbz2.1.0.dylib
+0x000000000d140000 	/usr/lib/liblzma.5.dylib
+0x000000000d140000 	/usr/lib/libbsm.0.dylib
+0x000000000d140000 	/usr/lib/libsqlite3.dylib
+0x000000000d140000 	/usr/lib/system/libkxld.dylib
+0x000000000d140000 	/usr/lib/libxar.1.dylib
+0x000000000d140000 	/usr/lib/libpam.2.dylib
+0x000000000d140000 	/usr/lib/libOpenScriptingUtil.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/FSEvents.framework/Versions/A/FSEvents
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/CarbonCore.framework/Versions/A/CarbonCore
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/Metadata.framework/Versions/A/Metadata
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/OSServices.framework/Versions/A/OSServices
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SearchKit.framework/Versions/A/SearchKit
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/AE.framework/Versions/A/AE
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/LaunchServices
+0x000000000d140000 	/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/DictionaryServices.framework/Versions/A/DictionaryServices
+0x000000000d140000 	/System/Library/Frameworks/NetFS.framework/Versions/A/NetFS
+0x000000000d140000 	/System/Library/PrivateFrameworks/NetAuth.framework/Versions/A/NetAuth
+0x000000000d140000 	/System/Library/PrivateFrameworks/login.framework/Versions/A/Frameworks/loginsupport.framework/Versions/A/loginsupport
+0x000000000d140000 	/System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC
+0x000000000d140000 	/usr/lib/libmecabra.dylib
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/ATS
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ColorSync.framework/Versions/A/ColorSync
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/HIServices.framework/Versions/A/HIServices
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/LangAnalysis.framework/Versions/A/LangAnalysis
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/PrintCore.framework/Versions/A/PrintCore
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/QD.framework/Versions/A/QD
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/SpeechSynthesis.framework/Versions/A/SpeechSynthesis
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Accelerate
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vImage.framework/Versions/A/vImage
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/vecLib
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvDSP.dylib
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvMisc.dylib
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLAPACK.dylib
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib
+0x000000000d140000 	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLinearAlgebra.dylib
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libFontParser.dylib
+0x000000000d140000 	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libFontRegistry.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/AppleVPA.framework/Versions/A/AppleVPA
+0x000000000d140000 	/System/Library/PrivateFrameworks/AppleJPEG.framework/Versions/A/AppleJPEG
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJPEG.dylib
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libTIFF.dylib
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libPng.dylib
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libGIF.dylib
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJP2.dylib
+0x000000000d140000 	/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libRadiance.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreVideo.framework/Versions/A/CoreVideo
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLU.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGFXShared.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLImage.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCVMSPluginSupport.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCoreVMClient.dylib
+0x000000000d140000 	/usr/lib/libcups.2.dylib
+0x000000000d140000 	/System/Library/Frameworks/Kerberos.framework/Versions/A/Kerberos
+0x000000000d140000 	/System/Library/Frameworks/GSS.framework/Versions/A/GSS
+0x000000000d140000 	/usr/lib/libresolv.9.dylib
+0x000000000d140000 	/usr/lib/libiconv.2.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/Heimdal.framework/Versions/A/Heimdal
+0x000000000d140000 	/usr/lib/libheimdal-asn1.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenDirectory.framework/Versions/A/OpenDirectory
+0x000000000d140000 	/System/Library/PrivateFrameworks/CommonAuth.framework/Versions/A/CommonAuth
+0x000000000d140000 	/System/Library/Frameworks/OpenDirectory.framework/Versions/A/Frameworks/CFOpenDirectory.framework/Versions/A/CFOpenDirectory
+0x000000000d140000 	/System/Library/Frameworks/SecurityFoundation.framework/Versions/A/SecurityFoundation
+0x000000000d140000 	/System/Library/PrivateFrameworks/LanguageModeling.framework/Versions/A/LanguageModeling
+0x000000000d140000 	/usr/lib/libcmph.dylib
+0x000000000d140000 	/System/Library/Frameworks/ServiceManagement.framework/Versions/A/ServiceManagement
+0x000000000d140000 	/usr/lib/libxslt.1.dylib
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Ink.framework/Versions/A/Ink
+0x000000000d140000 	/System/Library/Frameworks/QuartzCore.framework/Versions/A/Frameworks/CoreImage.framework/Versions/A/CoreImage
+0x000000000d140000 	/System/Library/PrivateFrameworks/CrashReporterSupport.framework/Versions/A/CrashReporterSupport
+0x000000000d140000 	/System/Library/Frameworks/OpenCL.framework/Versions/A/OpenCL
+0x000000000d140000 	/System/Library/PrivateFrameworks/FaceCore.framework/Versions/A/FaceCore
+0x000000000d140000 	/System/Library/PrivateFrameworks/Ubiquity.framework/Versions/A/Ubiquity
+0x000000000d140000 	/System/Library/PrivateFrameworks/IconServices.framework/Versions/A/IconServices
+0x000000000d140000 	/System/Library/PrivateFrameworks/ChunkingLibrary.framework/Versions/A/ChunkingLibrary
+0x000000000d140000 	/System/Library/PrivateFrameworks/Apple80211.framework/Versions/A/Apple80211
+0x000000000d140000 	/System/Library/Frameworks/CoreWLAN.framework/Versions/A/CoreWLAN
+0x000000000d140000 	/System/Library/Frameworks/IOBluetooth.framework/Versions/A/IOBluetooth
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreWiFi.framework/Versions/A/CoreWiFi
+0x000000000d140000 	/System/Library/Frameworks/CoreBluetooth.framework/Versions/A/CoreBluetooth
+0x000000000d140000 	/System/Library/PrivateFrameworks/DebugSymbols.framework/Versions/A/DebugSymbols
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/CoreSymbolication
+0x000000000d140000 	/System/Library/PrivateFrameworks/Symbolication.framework/Versions/A/Symbolication
+0x000000000d140000 	/System/Library/PrivateFrameworks/SpeechRecognitionCore.framework/Versions/A/SpeechRecognitionCore
+0x000000010c11b000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/server/libjvm.dylib
+0x000000000d140000 	/usr/lib/libstdc++.6.dylib
+0x000000010d154000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libverify.dylib
+0x000000010d162000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libjava.dylib
+0x000000010d1a0000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libzip.dylib
+0x0000000123a25000 	/System/Library/Frameworks/JavaVM.framework/Frameworks/JavaRuntimeSupport.framework/JavaRuntimeSupport
+0x0000000123a3b000 	/System/Library/Frameworks/JavaVM.framework/Versions/A/Frameworks/JavaNativeFoundation.framework/Versions/A/JavaNativeFoundation
+0x0000000123a4f000 	/System/Library/Frameworks/JavaVM.framework/Versions/A/JavaVM
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Carbon
+0x0000000123a5b000 	/System/Library/PrivateFrameworks/JavaLaunching.framework/Versions/A/JavaLaunching
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/CommonPanels.framework/Versions/A/CommonPanels
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Help.framework/Versions/A/Help
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/ImageCapture.framework/Versions/A/ImageCapture
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/OpenScripting.framework/Versions/A/OpenScripting
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Print.framework/Versions/A/Print
+0x000000000d140000 	/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SecurityHI.framework/Versions/A/SecurityHI
+0x00000001258e4000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libawt.dylib
+0x0000000125993000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/./libmlib_image.dylib
+0x0000000125a5f000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libawt_lwawt.dylib
+0x0000000125b12000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/./libosxapp.dylib
+0x000000000d140000 	/System/Library/Frameworks/ExceptionHandling.framework/Versions/A/ExceptionHandling
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreServicesInternal.framework/Versions/A/CoreServicesInternal
+0x000000000d140000 	/System/Library/PrivateFrameworks/CloudDocs.framework/Versions/A/CloudDocs
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreDuet.framework/Versions/A/CoreDuet
+0x000000000d140000 	/System/Library/Frameworks/CloudKit.framework/Versions/A/CloudKit
+0x000000000d140000 	/System/Library/PrivateFrameworks/ProtocolBuffer.framework/Versions/A/ProtocolBuffer
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreDuetDaemonProtocol.framework/Versions/A/CoreDuetDaemonProtocol
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreDuetDebugLogging.framework/Versions/A/CoreDuetDebugLogging
+0x000000000d140000 	/System/Library/Frameworks/CoreLocation.framework/Versions/A/CoreLocation
+0x000000000d140000 	/System/Library/Frameworks/Accounts.framework/Versions/A/Accounts
+0x000000000d140000 	/System/Library/PrivateFrameworks/ApplePushService.framework/Versions/A/ApplePushService
+0x000000000d140000 	/System/Library/PrivateFrameworks/GeoServices.framework/Versions/A/GeoServices
+0x000000000d140000 	/System/Library/PrivateFrameworks/OAuth.framework/Versions/A/OAuth
+0x000000000d140000 	/System/Library/PrivateFrameworks/CoreDaemon.framework/Versions/B/CoreDaemon
+0x000000000d140000 	/usr/lib/libcrypto.0.9.8.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/AppleSRP.framework/Versions/A/AppleSRP
+0x000000000d140000 	/System/Library/PrivateFrameworks/TrustEvaluationAgent.framework/Versions/A/TrustEvaluationAgent
+0x000000000d140000 	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Resources/libCGCMS.A.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Resources/libRIP.A.dylib
+0x000000000d140000 	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Resources/libCGXType.A.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenCL.framework/Versions/A/Libraries/libcldcpuengine.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/DiskImages.framework/Versions/A/DiskImages
+0x000000000d140000 	/System/Library/Frameworks/DiscRecording.framework/Versions/A/DiscRecording
+0x000000000d140000 	/usr/lib/libcsfde.dylib
+0x000000000d140000 	/usr/lib/libcurl.4.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/MediaKit.framework/Versions/A/MediaKit
+0x000000000d140000 	/System/Library/PrivateFrameworks/ProtectedCloudStorage.framework/Versions/A/ProtectedCloudStorage
+0x000000000d140000 	/usr/lib/libCoreStorage.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/EFILogin.framework/Versions/A/EFILogin
+0x000000000d140000 	/usr/lib/libutil.dylib
+0x000000000d140000 	/System/Library/PrivateFrameworks/FindMyDevice.framework/Versions/A/FindMyDevice
+0x000000000d140000 	/System/Library/Frameworks/LDAP.framework/Versions/A/LDAP
+0x000000000d140000 	/usr/lib/libsasl2.2.dylib
+0x000000012862f000 	cl_kernels
+0x0000000128631000 	/System/Library/Frameworks/OpenCL.framework/Versions/A/Libraries/ImageFormats/unorm8_bgra.dylib
+0x0000000128620000 	cl_kernels
+0x000000000d140000 	/System/Library/PrivateFrameworks/FamilyControls.framework/Versions/A/FamilyControls
+0x000000000d140000 	/System/Library/PrivateFrameworks/CommerceKit.framework/Versions/A/Frameworks/CommerceCore.framework/Versions/A/CommerceCore
+0x000000000d140000 	/System/Library/PrivateFrameworks/SystemAdministration.framework/Versions/A/SystemAdministration
+0x000000000d140000 	/System/Library/PrivateFrameworks/AppContainer.framework/Versions/A/AppContainer
+0x000000000d140000 	/System/Library/PrivateFrameworks/SecCodeWrapper.framework/Versions/A/SecCodeWrapper
+0x000000000d140000 	/System/Library/Frameworks/DirectoryService.framework/Versions/A/DirectoryService
+0x000000000d140000 	/System/Library/PrivateFrameworks/LoginUIKit.framework/Versions/A/Frameworks/LoginUICore.framework/Versions/A/LoginUICore
+0x000000000d140000 	/usr/lib/libodfde.dylib
+0x00000001298fa000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libfontmanager.dylib
+0x0000000129961000 	/Users/ShantalOlono/Life/slick/liblwjgl.dylib
+0x0000000127b65000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libjawt.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Resources/GLEngine.bundle/GLEngine
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLProgrammability.dylib
+0x0000000000000000 	/System/Library/Extensions/AppleIntelHD4000GraphicsGLDriver.bundle/Contents/MacOS/AppleIntelHD4000GraphicsGLDriver
+0x000000000d140000 	/System/Library/PrivateFrameworks/IOAccelerator.framework/Versions/A/IOAccelerator
+0x000000000d140000 	/System/Library/PrivateFrameworks/GPUSupport.framework/Versions/A/Libraries/libGPUSupportMercury.dylib
+0x000000000d140000 	/System/Library/Frameworks/OpenGL.framework/Versions/A/Resources/GLRendererFloat.bundle/GLRendererFloat
+0x000000012a1e6000 	/Users/ShantalOlono/Life/slick/libjinput-osx.dylib
+0x000000012a1eb000 	/System/Library/Extensions/IOHIDFamily.kext/Contents/PlugIns/IOHIDLib.plugin/Contents/MacOS/IOHIDLib
+0x0000000138386000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libnet.dylib
+0x00000001382cc000 	/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib/libnio.dylib
+
+VM Arguments:
+jvm_args: -Djava.library.path=/Users/ShantalOlono/Life/slick -Dfile.encoding=UTF-8 
+java_command: main.java.edu.asu.cst316.Game
+java_class_path (initial): /Users/ShantalOlono/Life/bin:/Users/ShantalOlono/Life/jar/jacocoagent.jar:/Users/ShantalOlono/Life/jar/jacocoant.jar:/Users/ShantalOlono/Life/jar/junit.jar:/Users/ShantalOlono/Life/jar/org.jacoco.agent-0.7.4.201502262128.jar:/Users/ShantalOlono/Life/jar/org.jacoco.ant-0.7.4.201502262128.jar:/Users/ShantalOlono/Life/jar/org.jacoco.core-0.7.4.201502262128.jar:/Users/ShantalOlono/Life/jar/org.jacoco.report-0.7.4.201502262128.jar:/Users/ShantalOlono/Life/slick/lib/commons-math3-3.3.jar:/Users/ShantalOlono/Life/slick/lib/ibxm.jar:/Users/ShantalOlono/Life/slick/lib/jinput.jar:/Users/ShantalOlono/Life/slick/lib/jnlp.jar:/Users/ShantalOlono/Life/slick/lib/jogg-0.0.7.jar:/Users/ShantalOlono/Life/slick/lib/jorbis-0.0.15.jar:/Users/ShantalOlono/Life/slick/lib/lwjgl_util_applet.jar:/Users/ShantalOlono/Life/slick/lib/lwjgl_util.jar:/Users/ShantalOlono/Life/slick/lib/lwjgl.jar:/Users/ShantalOlono/Life/slick/lib/natives-linux.jar:/Users/ShantalOlono/Life/slick/lib/natives-mac.jar:/Users/ShantalOlono/Life/slick/lib/natives-windows.jar:/Users/ShantalOlono/Life/slick/lib/Pack200Task.jar:/Users/ShantalOlono/Life/slick/lib/slick-examples.jar:/Users/ShantalOlono/Life/slick/lib/slick.jar:/Users/ShantalOlono/Life/slick/lib/tinylinepp.jar
+Launcher Type: SUN_STANDARD
+
+Environment Variables:
+PATH=/usr/bin:/bin:/usr/sbin:/sbin
+SHELL=/bin/bash
+
+Signal Handlers:
+SIGSEGV: [libjvm.dylib+0x57a0e7], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_ONSTACK|SA_RESTART|SA_SIGINFO
+SIGBUS: [libjvm.dylib+0x57a0e7], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGFPE: [libjvm.dylib+0x45af24], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGPIPE: [libjvm.dylib+0x45af24], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGXFSZ: [libjvm.dylib+0x45af24], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGILL: [libjvm.dylib+0x45af24], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGUSR1: SIG_DFL, sa_mask[0]=00000000000000000000000000000000, sa_flags=none
+SIGUSR2: [libjvm.dylib+0x45aa42], sa_mask[0]=00100000000000000000000000000000, sa_flags=SA_RESTART|SA_SIGINFO
+SIGHUP: [libjvm.dylib+0x459015], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGINT: [libjvm.dylib+0x459015], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGTERM: [libjvm.dylib+0x459015], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+SIGQUIT: [libjvm.dylib+0x459015], sa_mask[0]=11111111011111110111111111111111, sa_flags=SA_RESTART|SA_SIGINFO
+
+
+---------------  S Y S T E M  ---------------
+
+OS:Bsduname:Darwin 14.1.0 Darwin Kernel Version 14.1.0: Mon Dec 22 23:10:38 PST 2014; root:xnu-2782.10.72~2/RELEASE_X86_64 x86_64
+rlimit: STACK 8192k, CORE 0k, NPROC 709, NOFILE 10240, AS infinity
+load average:2.85 2.54 2.28
+
+CPU:total 4 (2 cores per cpu, 2 threads per core) family 6 model 58 stepping 9, cmov, cx8, fxsr, mmx, sse, sse2, sse3, ssse3, sse4.1, sse4.2, popcnt, avx, aes, clmul, erms, ht, tsc, tscinvbit, tscinv
+
+Memory: 4k page, physical 8388608k(745444k free)
+
+/proc/meminfo:
+
+
+vm_info: Java HotSpot(TM) 64-Bit Server VM (25.31-b07) for bsd-amd64 JRE (1.8.0_31-b13), built on Dec 17 2014 20:45:36 by "java_re" with gcc 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2336.11.00)
+
+time: Mon Apr 20 18:17:13 2015
+elapsed time: 15 seconds (0d 0h 0m 15s)
+

--- a/src/main/java/edu/asu/cst316/CharacterCreationMenu.java
+++ b/src/main/java/edu/asu/cst316/CharacterCreationMenu.java
@@ -39,7 +39,7 @@ public class CharacterCreationMenu extends BasicGameState{
 		careerName = new TextField(gc, trueTypeFont, 330, 210, 290, 45);
 		careerName.setBackgroundColor(new Color(20, 25, 34));
 		careerName.setTextColor(new Color(234, 226, 217));
-		careerName.setText("newPlayer");
+		careerName.setText("");
 	}
 
 	//@Override
@@ -89,19 +89,20 @@ public class CharacterCreationMenu extends BasicGameState{
 		xPosition < 773 &&
 		yPosition < 64 &&
 		yPosition > 18){
+			entrP.setName(careerName.getText());
 			sbg.enterState(2);
 		}
 		
 		//venture 1
 		if(input.isMouseButtonDown(0) &&
 		xPosition > 330 &&
-		xPosition < 415 &&
+		xPosition < 460 &&
 		yPosition < 285 &&
 		yPosition > 250){
 			
 			System.out.println(careerName.getText());
 			entrP.setName(careerName.getText());
-			entrP.setCareer("venture 1");
+			entrP.setCareer("Venture 1");
 			entrP.setIncome(10000);
 			entrP.setSavedMoney(50000);
 			entrP.setRisk(4);
@@ -110,12 +111,12 @@ public class CharacterCreationMenu extends BasicGameState{
 		//venture 2
 		if(input.isMouseButtonDown(0) &&
 		xPosition > 330 &&
-		xPosition < 415 &&
+		xPosition < 460 &&
 		yPosition < 235 &&
 		yPosition > 200){
 			System.out.println(careerName.getText());
 			entrP.setName(careerName.getText());
-			entrP.setCareer("venture 2");
+			entrP.setCareer("Venture 2");
 			entrP.setIncome(15000);
 			entrP.setSavedMoney(50000);
 			entrP.setRisk(6);
@@ -124,12 +125,10 @@ public class CharacterCreationMenu extends BasicGameState{
 		//venture 3
 		if(input.isMouseButtonDown(0) &&
 		xPosition > 330 &&
-		xPosition < 415 &&
+		xPosition < 460 &&
 		yPosition < 185 &&
 		yPosition > 150){
-			System.out.println(careerName.getText());
-			entrP.setName(careerName.getText());
-			entrP.setCareer("venture 3");
+			entrP.setCareer("Venture 3");
 			entrP.setIncome(20000);
 			entrP.setSavedMoney(50000);
 			entrP.setRisk(8);


### PR DESCRIPTION
Fixed all 3 bugs that I found in the game for Select Market Sector Fix.
-The user is now able to click anywhere from the beginning of "V" to
the end which is the number associated with "Venture". Example "Venture
1", user can click anywhere from "V" to "1" and it will select it.
-The user can now enter in their name without having to move anything
with the right arrow key or click on anything, even if they click on a
venture first.
-The user is now able to click on the Venture first and then enter in
their name, which will upload to the game, vice versa.
